### PR TITLE
Changed from String to Cow<'static, str>

### DIFF
--- a/crates/bevy_granite_core/src/assets/materials/definition.rs
+++ b/crates/bevy_granite_core/src/assets/materials/definition.rs
@@ -893,8 +893,8 @@ impl EditableMaterial {
 
         // Try to delete the file from disk
         if !self.path.is_empty() {
-            let abs_path = rel_asset_to_absolute(self.path.clone());
-            let file_path = abs_path;
+            let abs_path = rel_asset_to_absolute(&self.path);
+            let file_path = abs_path.to_string();
 
             if std::fs::metadata(&file_path).is_ok() {
                 match std::fs::remove_file(&file_path) {

--- a/crates/bevy_granite_core/src/assets/materials/definition.rs
+++ b/crates/bevy_granite_core/src/assets/materials/definition.rs
@@ -1,5 +1,4 @@
 use bevy::math::Affine2;
-use bevy::pbr::MeshMaterial3d;
 use bevy::prelude::{
     AlphaMode, AssetServer, Assets, Color, Handle, Image, Reflect, Res, ResMut, Resource,
     StandardMaterial,
@@ -193,8 +192,8 @@ impl EditableMaterial {
     pub fn is_empty(&self) -> bool {
         self.path.is_empty()
             || self.friendly_name.is_empty()
-            || self.friendly_name == "None".to_string()
-            || self.friendly_name == "Empty".to_string()
+            || self.friendly_name == "None"
+            || self.friendly_name == "Empty"
     }
 
     pub fn set_handle(&mut self, handle: Option<Handle<StandardMaterial>>) {
@@ -806,12 +805,12 @@ impl EditableMaterial {
         available_materials: &mut ResMut<AvailableEditableMaterials>,
         materials: &mut ResMut<Assets<StandardMaterial>>,
         asset_server: &Res<AssetServer>,
-        fallback_name: &String,
-        fallback_path: &String,
+        fallback_name: &str,
+        fallback_path: &str,
     ) -> bool {
         let mut saved_new_material = false;
 
-        if *fallback_path == "".to_string() {
+        if fallback_path.is_empty() {
             return false;
         }
 
@@ -827,19 +826,16 @@ impl EditableMaterial {
                 fallback_path
             );
 
-            self.update_name(fallback_name.clone().to_lowercase());
-            self.update_path(fallback_path.clone().to_lowercase());
+            self.update_name(fallback_name.to_lowercase());
+            self.update_path(fallback_path.to_lowercase());
             self.save_to_file();
             saved_new_material = true;
         };
 
         // Ensure whatever material we have is a part of the scene
-        if let Some(material) = material_from_path_into_scene(
-            &mut self.path,
-            materials,
-            available_materials,
-            &asset_server,
-        ) {
+        if let Some(material) =
+            material_from_path_into_scene(&self.path, materials, available_materials, asset_server)
+        {
             *self = material;
         }
         saved_new_material

--- a/crates/bevy_granite_core/src/assets/materials/load.rs
+++ b/crates/bevy_granite_core/src/assets/materials/load.rs
@@ -411,12 +411,10 @@ fn collect_material_files_recursive(current_dir: &str, ron_files: &mut Vec<Strin
 
 /// Loads a material from a path and returns it if it exists
 pub fn get_material_from_path(
-    path: &mut String,
+    path: &str,
     materials: &mut ResMut<Assets<StandardMaterial>>,
     available_materials: &mut ResMut<AvailableEditableMaterials>,
     asset_server: &Res<AssetServer>,
 ) -> Option<EditableMaterial> {
-    let material =
-        material_from_path_into_scene(&path, materials, available_materials, asset_server);
-    material
+    material_from_path_into_scene(path, materials, available_materials, asset_server)
 }

--- a/crates/bevy_granite_core/src/assets/plugin.rs
+++ b/crates/bevy_granite_core/src/assets/plugin.rs
@@ -27,8 +27,8 @@ fn preload_fallback_material(
         &mut available_materials,
         &mut materials,
         &asset_server,
-        &String::new(),
-        &String::new(),
+        "",
+        "",
     );
 
     if let Some(ref mut materials) = available_materials.materials {

--- a/crates/bevy_granite_core/src/entities/component_editor.rs
+++ b/crates/bevy_granite_core/src/entities/component_editor.rs
@@ -3,7 +3,7 @@ use bevy::{
     reflect::{FromType, ReflectDeserialize, TypeRegistration},
 };
 use bevy_granite_logging::{log, LogCategory, LogLevel, LogType};
-use std::{any::Any, collections::HashMap};
+use std::{any::Any, borrow::Cow, collections::HashMap};
 
 // All structs defined by #[granite_component]
 // get this tag so we can easily filter in UI
@@ -32,7 +32,7 @@ pub fn is_exposed_bevy_component(registration: &TypeRegistration) -> bool {
 
 #[derive(Debug)]
 pub struct ReflectedComponent {
-    pub type_name: String,
+    pub type_name: Cow<'static, str>,
     pub reflected_data: Box<dyn PartialReflect>,
     pub type_registration: TypeRegistration,
 }
@@ -112,7 +112,7 @@ impl ComponentEditor {
                         if let Some(reflected) = reflect_component.reflect(entity_ref) {
                             if let Ok(clone) = reflected.reflect_clone() {
                                 components.push(ReflectedComponent {
-                                    type_name: type_name.to_string(),
+                                    type_name: type_name.into(),
                                     reflected_data: clone,
                                     type_registration: registration.clone(),
                                 });

--- a/crates/bevy_granite_core/src/entities/component_editor.rs
+++ b/crates/bevy_granite_core/src/entities/component_editor.rs
@@ -60,8 +60,6 @@ impl PartialEq for ReflectedComponent {
     }
 }
 
-///
-
 #[derive(Resource, Clone, Default)]
 pub struct ComponentEditor {
     pub selected_entity: Option<Entity>,

--- a/crates/bevy_granite_core/src/entities/deserialize.rs
+++ b/crates/bevy_granite_core/src/entities/deserialize.rs
@@ -61,7 +61,7 @@ pub fn deserialize_entities(
             materials,
             available_materials,
             &mut meshes,
-            &save_data,
+            save_data,
         );
 
         // Map the stored GUID to the new entity

--- a/crates/bevy_granite_core/src/entities/deserialize.rs
+++ b/crates/bevy_granite_core/src/entities/deserialize.rs
@@ -15,8 +15,8 @@ use bevy_granite_logging::{
 };
 use ron::de::from_str;
 use serde::{Deserialize, Serialize};
-use std::fs::File;
 use std::io::Read;
+use std::{borrow::Cow, fs::File};
 use uuid::Uuid;
 
 // Main component to tag all of our custom entity class types
@@ -35,8 +35,9 @@ pub fn deserialize_entities(
     materials: &mut ResMut<Assets<StandardMaterial>>,
     available_materials: &mut ResMut<AvailableEditableMaterials>,
     mut meshes: ResMut<Assets<Mesh>>,
-    abs_path: String, //absolute
+    abs_path: impl Into<Cow<'static, str>>, //absolute
 ) {
+    let abs_path: Cow<'static, str> = abs_path.into();
     // Build materials from the folder and load them into the scene
     materials_from_folder_into_scene("materials", materials, available_materials, asset_server);
 
@@ -45,7 +46,7 @@ pub fn deserialize_entities(
         asset_server,
         materials,
         available_materials,
-        abs_path.clone(),
+        abs_path.as_ref(),
     );
 
     // for id
@@ -68,8 +69,8 @@ pub fn deserialize_entities(
         uuid_to_entity_map.insert(save_data.identity.uuid, entity);
 
         // Tag entity with its source file
-        let relative = absolute_asset_to_rel(abs_path.clone());
-        commands.entity(entity).insert(SpawnSource(relative));
+        let relative: Cow<'static, str> = absolute_asset_to_rel(abs_path.to_string());
+        commands.entity(entity).insert(SpawnSource::new(relative));
 
         // Store parent relationships for second pass
         if let Some(parent_guid) = save_data.parent {
@@ -159,7 +160,7 @@ fn gather_file_contents(
     asset_server: &Res<AssetServer>,
     materials: &mut ResMut<Assets<StandardMaterial>>,
     available_materials: &mut ResMut<AvailableEditableMaterials>,
-    path: String,
+    path: &str,
 ) -> Vec<EntitySaveReadyData> {
     log!(
         LogType::Game,

--- a/crates/bevy_granite_core/src/entities/editable/definition.rs
+++ b/crates/bevy_granite_core/src/entities/editable/definition.rs
@@ -43,8 +43,8 @@ pub trait GraniteType {
     /// If we require user input, this is the config to send to the dialog browser
     /// Base path is first string - relative!
     /// Second list of vectors is file extensions to show in popup
-    fn get_prompt_config(&self) -> (String, Vec<String>) {
-        ("".to_string(), vec!["*".to_string()])
+    fn get_prompt_config(&self) -> (String, Vec<&'static str>) {
+        ("".to_string(), vec!["*"])
     }
 
     /// Provide the embedded icon bytes - override this if your type has an icon

--- a/crates/bevy_granite_core/src/entities/editable/types/obj/mod.rs
+++ b/crates/bevy_granite_core/src/entities/editable/types/obj/mod.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::{
     entities::editable::{
         GraniteType, RequestEntityUpdateFromClass, RequiredMaterialData, RequiredMaterialDataMut,
@@ -40,13 +42,13 @@ pub struct UserUpdatedOBJEvent {
 /// OBJ needs materials, so we pass the required MaterialData which contains, path, current and last materials
 #[derive(Serialize, Deserialize, Reflect, Debug, Clone, PartialEq)]
 pub struct OBJ {
-    pub mesh_path: String,
+    pub mesh_path: Cow<'static, str>,
     pub material: MaterialData,
 }
 impl Default for OBJ {
     fn default() -> Self {
         Self {
-            mesh_path: "".to_string(),
+            mesh_path: "".into(),
             material: MaterialData::new("".to_string()),
         }
     }
@@ -70,8 +72,8 @@ impl GraniteType for OBJ {
         true
     }
 
-    fn get_prompt_config(&self) -> (String, Vec<String>) {
-        ("models".to_string(), vec!["obj".to_string()])
+    fn get_prompt_config(&self) -> (String, Vec<&'static str>) {
+        ("models".to_string(), vec!["obj"])
     }
 
     fn spawn_from_new_identity(

--- a/crates/bevy_granite_core/src/entities/generate_tangents.rs
+++ b/crates/bevy_granite_core/src/entities/generate_tangents.rs
@@ -1,6 +1,4 @@
-use bevy::prelude::{
-    AssetServer, Assets, Commands, Component, Entity, Handle, Query, Res, ResMut, With,
-};
+use bevy::prelude::{AssetServer, Assets, Commands, Component, Entity, Query, Res, ResMut, With};
 use bevy::render::mesh::*;
 use bevy_granite_logging::{
     config::{LogCategory, LogLevel, LogType},

--- a/crates/bevy_granite_core/src/entities/mod.rs
+++ b/crates/bevy_granite_core/src/entities/mod.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use bevy::{
     ecs::component::Component,
     ecs::resource::Resource,
@@ -29,7 +31,23 @@ pub struct MainCamera;
 /// String is relative path from /assets
 #[derive(Reflect, Serialize, Deserialize, Debug, Clone, Component, Default, PartialEq)]
 #[reflect(Component, Serialize, Deserialize, Default, FromReflect)]
-pub struct SpawnSource(pub String);
+pub struct SpawnSource(Cow<'static, str>);
+impl SpawnSource {
+    pub fn new(path: impl Into<Cow<'static, str>>) -> Self {
+        Self(path.into())
+    }
+
+    pub fn str_ref(&self) -> &str {
+        self.0.as_ref()
+    }
+}
+
+impl core::ops::Deref for SpawnSource {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref()
+    }
+}
 
 /// Camera for UI Editor Elements
 #[derive(Reflect, Serialize, Deserialize, Debug, Clone, Component, Default, PartialEq)]

--- a/crates/bevy_granite_core/src/entities/mod.rs
+++ b/crates/bevy_granite_core/src/entities/mod.rs
@@ -156,12 +156,12 @@ pub use lifecycle::{
 pub use plugin::EntityPlugin;
 pub use serialize::{serialize_entities, EntitySaveReadyData, SceneData, SceneMetadata};
 
-/// A marker component that an entity should be ignored by the editor
-/// This will be more powerful then not having Bridge
-/// As this is explicitly added to an entity
 // Im adding this so you cant select the editor camera
 // and to stop a crash because you can select a gizmo that then despawns its self
 bitflags::bitflags! {
+    /// A marker component that an entity should be ignored by the editor
+    /// This will be more powerful then not having Bridge
+    /// As this is explicitly added to an entity
     #[derive(bevy::ecs::component::Component, Default)]
     pub struct EditorIgnore: usize {
         const GIZMO = 1;

--- a/crates/bevy_granite_core/src/setup.rs
+++ b/crates/bevy_granite_core/src/setup.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::entities::{is_bridge_component_check, ComponentEditor};
 use bevy::{
     ecs::reflect::AppTypeRegistry,
@@ -8,7 +10,7 @@ use bevy_granite_logging::{log, LogCategory, LogLevel, LogType};
 
 #[derive(Resource, Default)]
 pub struct RegisteredTypeNames {
-    pub names: Vec<String>,
+    pub names: Vec<Cow<'static, str>>,
 }
 
 pub fn gather_registered_types(
@@ -34,7 +36,7 @@ pub fn gather_registered_types(
     );
 }
 
-fn get_bridge_reflect_component_names(type_registry: &TypeRegistry) -> Vec<String> {
+fn get_bridge_reflect_component_names(type_registry: &TypeRegistry) -> Vec<Cow<'static, str>> {
     type_registry
         .iter()
         .filter(|registration| {
@@ -42,7 +44,7 @@ fn get_bridge_reflect_component_names(type_registry: &TypeRegistry) -> Vec<Strin
                 is_bridge_component_check(registration)
             }
         })
-        .map(|registration| registration.type_info().type_path().to_string())
+        .map(|registration| registration.type_info().type_path().into())
         .collect()
 }
 
@@ -62,7 +64,7 @@ pub fn setup_component_editor(
 /// this will return all the bevy componets that should be accessible in the editor
 /// this is a big hack for now because I just need one componet and cant be fucked making a proper dynamic implementation
 /// this whole approch will need to be redone in the future - Use Cow<'static str> FFS
-fn get_bevy_reflect_component_names(type_registry: &TypeRegistry) -> Vec<String> {
+fn get_bevy_reflect_component_names(type_registry: &TypeRegistry) -> Vec<Cow<'static, str>> {
     vec![type_registry
         .get(std::any::TypeId::of::<
             bevy::core_pipeline::tonemapping::Tonemapping,
@@ -70,5 +72,5 @@ fn get_bevy_reflect_component_names(type_registry: &TypeRegistry) -> Vec<String>
         .expect("Tonemapping to be registered")
         .type_info()
         .type_path()
-        .to_string()]
+        .into()]
 }

--- a/crates/bevy_granite_core/src/shared/file.rs
+++ b/crates/bevy_granite_core/src/shared/file.rs
@@ -1,30 +1,34 @@
-use std::path::Path;
 use bevy::asset::io::file::FileAssetReader;
+use std::{borrow::Cow, path::Path};
 
-pub fn rel_asset_to_absolute(rel_string: String) -> String {
+pub fn rel_asset_to_absolute<'a>(rel_string: &'a str) -> Cow<'a, str> {
     if !Path::new(&rel_string).is_absolute() {
-        let abs_path = FileAssetReader::get_base_path()
+        FileAssetReader::get_base_path()
             .join(format!("assets/{}", rel_string))
             .to_string_lossy()
-            .to_string();
-        abs_path
+            .to_string()
+            .into()
     } else {
-        rel_string
+        rel_string.into()
     }
 }
 
-pub fn absolute_asset_to_rel(abs_string: String) -> String {
+pub fn absolute_asset_to_rel(abs_string: String) -> Cow<'static, str> {
     let abs_path = Path::new(&abs_string);
-    
+
     if abs_path.is_absolute() {
         let base_assets_path = FileAssetReader::get_base_path().join("assets");
-        
+
         if let Ok(rel_path) = abs_path.strip_prefix(&base_assets_path) {
-            rel_path.to_string_lossy().to_string().replace("\\", "/")
+            rel_path
+                .to_string_lossy()
+                .to_string()
+                .replace("\\", "/")
+                .into()
         } else {
-            abs_string
+            abs_string.into()
         }
     } else {
-        abs_string
+        abs_string.into()
     }
 }

--- a/crates/bevy_granite_core/src/shared/file_browser.rs
+++ b/crates/bevy_granite_core/src/shared/file_browser.rs
@@ -4,8 +4,7 @@ use bevy_granite_logging::{
 };
 use native_dialog::FileDialog;
 
-pub fn asset_file_browser(path: String, filter: Vec<String>) -> Option<String> {
-    let filter_refs: Vec<&str> = filter.iter().map(|s| s.as_str()).collect();
+pub fn asset_file_browser(path: String, filter: Vec<&str>) -> Option<String> {
     let current_dir = std::env::current_dir().unwrap();
     let assets_dir = current_dir.join("assets");
     let location = assets_dir.join(&path);
@@ -43,7 +42,7 @@ pub fn asset_file_browser(path: String, filter: Vec<String>) -> Option<String> {
 
     if let Some(selected_path) = FileDialog::new()
         .set_location(&location)
-        .add_filter("Files", &filter_refs)
+        .add_filter("Files", &filter)
         .show_open_single_file()
         .unwrap()
     {
@@ -63,8 +62,7 @@ pub fn asset_file_browser(path: String, filter: Vec<String>) -> Option<String> {
     }
 }
 
-pub fn asset_file_browser_multiple(path: String, filter: Vec<String>) -> Option<Vec<String>> {
-    let filter_refs: Vec<&str> = filter.iter().map(|s| s.as_str()).collect();
+pub fn asset_file_browser_multiple(path: String, filter: Vec<&str>) -> Option<Vec<String>> {
     let current_dir = std::env::current_dir().unwrap();
     let assets_dir = current_dir.join("assets");
     let location = assets_dir.join(&path);
@@ -102,7 +100,7 @@ pub fn asset_file_browser_multiple(path: String, filter: Vec<String>) -> Option<
 
     let selected_paths = FileDialog::new()
         .set_location(&location)
-        .add_filter("Files", &filter_refs)
+        .add_filter("Files", &filter)
         .show_open_multiple_file()
         .unwrap();
 
@@ -111,7 +109,7 @@ pub fn asset_file_browser_multiple(path: String, filter: Vec<String>) -> Option<
     }
 
     let mut valid_paths = Vec::new();
-    
+
     for path in selected_paths {
         if path.starts_with(&assets_dir) {
             valid_paths.push(path.to_string_lossy().to_string());
@@ -125,7 +123,7 @@ pub fn asset_file_browser_multiple(path: String, filter: Vec<String>) -> Option<
             );
         }
     }
-    
+
     if valid_paths.is_empty() {
         None
     } else {

--- a/crates/bevy_granite_editor/src/editor_state/config.rs
+++ b/crates/bevy_granite_editor/src/editor_state/config.rs
@@ -105,9 +105,9 @@ impl PopupHelpText {
     }
 }
 
-pub static UI_CONFIG: LazyLock<UiConfig> = LazyLock::new(|| UiConfig::from_toml());
-pub static HELP_CONFIG: LazyLock<PopupHelpText> = LazyLock::new(|| PopupHelpText::from_toml());
-pub static INPUT_CONFIG: LazyLock<InputConfig> = LazyLock::new(|| InputConfig::from_toml());
+pub static UI_CONFIG: LazyLock<UiConfig> = LazyLock::new(UiConfig::from_toml);
+pub static HELP_CONFIG: LazyLock<PopupHelpText> = LazyLock::new(PopupHelpText::from_toml);
+pub static INPUT_CONFIG: LazyLock<InputConfig> = LazyLock::new(InputConfig::from_toml);
 
 pub static INTERFACE_CONFIG: LazyLock<toml::Value> = LazyLock::new(|| {
     toml::from_str(INTERFACE_CONFIG_TOML).expect("Failed to parse config.toml configuration")

--- a/crates/bevy_granite_editor/src/editor_state/editor.rs
+++ b/crates/bevy_granite_editor/src/editor_state/editor.rs
@@ -19,11 +19,8 @@ use bevy_granite_logging::{
 };
 
 use crate::interface::RequestEditorToggle;
-use bevy::prelude::{Children, Commands, Entity, Query, With};
-use bevy_granite_gizmos::{
-    despawn_rotate_gizmo, selection::events::EntityEvent, ActiveSelection, GizmoVisibilityState,
-    RotateGizmo, Selected, TransformGizmo,
-};
+use bevy::prelude::Commands;
+use bevy_granite_gizmos::{selection::events::EntityEvent, GizmoVisibilityState};
 
 // editor.rs
 // This has functions related to saving the editor settings
@@ -112,8 +109,6 @@ pub fn update_editor_vis_system(
     mut editor_state: ResMut<EditorState>,
     mut gizmo_state: ResMut<GizmoVisibilityState>,
     mut commands: Commands,
-    selection: Query<Entity, With<Selected>>,
-    active_selection: Query<Entity, With<ActiveSelection>>,
 ) {
     for RequestEditorToggle in toggle_reader.read() {
         // have to do it manually as watchers wont run when not active

--- a/crates/bevy_granite_editor/src/editor_state/editor.rs
+++ b/crates/bevy_granite_editor/src/editor_state/editor.rs
@@ -64,8 +64,8 @@ pub fn update_active_world_system(
 
     for WorldLoadSuccessEvent(path) in open_success_reader.read() {
         let rel_path = absolute_asset_to_rel(path.to_string());
-        editor_state.current_file = Some(rel_path.clone());
-        editor_state.loaded_sources.insert(rel_path.clone());
+        editor_state.current_file = Some(rel_path.to_string());
+        editor_state.loaded_sources.insert(rel_path.to_string());
         log!(
             LogType::Editor,
             LogLevel::Info,
@@ -78,7 +78,7 @@ pub fn update_active_world_system(
 
     for WorldSaveSuccessEvent(path) in world_save_success_reader.read() {
         let rel_path = absolute_asset_to_rel(path.to_string());
-        editor_state.loaded_sources.insert(rel_path.clone());
+        editor_state.loaded_sources.insert(rel_path.to_string());
         log!(
             LogType::Editor,
             LogLevel::Info,
@@ -91,8 +91,8 @@ pub fn update_active_world_system(
 
     for SetActiveWorld(path) in set_active_world_reader.read() {
         let rel_path = absolute_asset_to_rel(path.to_string());
-        editor_state.current_file = Some(rel_path.clone());
-        editor_state.loaded_sources.insert(rel_path.clone());
+        editor_state.current_file = Some(rel_path.to_string());
+        editor_state.loaded_sources.insert(rel_path.to_string());
         log!(
             LogType::Editor,
             LogLevel::Info,

--- a/crates/bevy_granite_editor/src/entities/bounds.rs
+++ b/crates/bevy_granite_editor/src/entities/bounds.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::{Assets, Entity, Handle, Mesh, Query, Vec3};
+use bevy::prelude::{Assets, Entity, Mesh, Query, Vec3};
 use bevy::render::mesh::{Mesh3d, VertexAttributeValues};
 use bevy::transform::components::GlobalTransform;
 use bevy_granite_core::{ClassCategory, GraniteType, IdentityData};

--- a/crates/bevy_granite_editor/src/entities/creation.rs
+++ b/crates/bevy_granite_editor/src/entities/creation.rs
@@ -2,10 +2,9 @@ use crate::{editor_state::EditorState, interface::UserRequestGraniteTypeViaPopup
 use bevy::{
     asset::{AssetServer, Assets},
     ecs::{
-        event::{EventReader, EventWriter},
+        event::EventReader,
         system::{Commands, Res, ResMut},
     },
-    math::Vec3,
     pbr::StandardMaterial,
     prelude::Resource,
     render::mesh::Mesh,
@@ -51,8 +50,7 @@ pub fn new_entity_via_popup_system(
             class
         );
 
-        let mut transform = Transform::default();
-        transform.translation = Vec3::ZERO;
+        let transform = Transform::default();
 
         let source = editor_state
             .current_file

--- a/crates/bevy_granite_editor/src/entities/creation.rs
+++ b/crates/bevy_granite_editor/src/entities/creation.rs
@@ -129,7 +129,7 @@ pub fn process_entity_spawn_queue_system(
         // Tag entity with spawn source
         commands
             .entity(entity)
-            .insert(SpawnSource(pending.source.clone()));
+            .insert(SpawnSource::new(pending.source.clone()));
 
         let additive = pending.batch_size > 1;
         let remaining = spawn_queue.pending.len();

--- a/crates/bevy_granite_editor/src/entities/relationship.rs
+++ b/crates/bevy_granite_editor/src/entities/relationship.rs
@@ -8,7 +8,7 @@ use crate::interface::{
 use bevy::{
     ecs::{
         entity::Entity,
-        event::{EventReader, EventWriter},
+        event::EventReader,
         query::{With, Without},
         system::{Commands, Query},
     },

--- a/crates/bevy_granite_editor/src/interface/cache/entity_cache.rs
+++ b/crates/bevy_granite_editor/src/interface/cache/entity_cache.rs
@@ -1,7 +1,7 @@
 use crate::interface::tabs::entity_editor::widgets::EntityRegisteredData;
 use bevy::{
     pbr::{MeshMaterial3d, StandardMaterial},
-    prelude::{Entity, Handle, Resource},
+    prelude::{Entity, Resource},
 };
 use bevy_granite_core::{IdentityData, TransformData};
 use bevy_granite_gizmos::DragState;

--- a/crates/bevy_granite_editor/src/interface/cache/entity_cache_system.rs
+++ b/crates/bevy_granite_editor/src/interface/cache/entity_cache_system.rs
@@ -3,7 +3,6 @@ use crate::interface::{
     tabs::entity_editor::EntityRegisteredData,
 };
 use bevy::{
-    asset::Handle,
     pbr::{MeshMaterial3d, StandardMaterial},
     prelude::{Entity, Name, Transform, World},
     transform::components::GlobalTransform,

--- a/crates/bevy_granite_editor/src/interface/layout/dock.rs
+++ b/crates/bevy_granite_editor/src/interface/layout/dock.rs
@@ -81,7 +81,7 @@ pub fn dock_ui_system(
             });
         });
 
-    let side_panel_position = editor_state.config.dock.side_panel_position.clone();
+    let side_panel_position = editor_state.config.dock.side_panel_position;
     match side_panel_position {
         SidePanelPosition::Left => {
             egui::SidePanel::left("left_dock_panel")

--- a/crates/bevy_granite_editor/src/interface/layout/top_bar.rs
+++ b/crates/bevy_granite_editor/src/interface/layout/top_bar.rs
@@ -59,7 +59,7 @@ pub fn top_bar_ui(
                 if ui.button("Save (Ctrl + S)").clicked() {
                     let loaded = &editor_state.loaded_sources;
                     if !loaded.is_empty() {
-                        for (_index, source) in loaded.iter().enumerate() {
+                        for source in loaded.iter() {
                             events.save.write(RequestSaveEvent(source.to_string()));
                         }
                     }

--- a/crates/bevy_granite_editor/src/interface/plugin.rs
+++ b/crates/bevy_granite_editor/src/interface/plugin.rs
@@ -21,7 +21,7 @@ use super::{
 use crate::{interface::RequestRemoveParentsFromEntities, setup::is_editor_active};
 use bevy::{
     ecs::schedule::IntoScheduleConfigs,
-    prelude::{App, Handle, Mesh, Plugin, StandardMaterial, Update},
+    prelude::{App, Handle, Mesh, Plugin, StandardMaterial},
 };
 use bevy_egui::EguiPrimaryContextPass;
 

--- a/crates/bevy_granite_editor/src/interface/popups/add_entity_ui.rs
+++ b/crates/bevy_granite_editor/src/interface/popups/add_entity_ui.rs
@@ -29,7 +29,7 @@ pub fn add_entity_ui(
         // call this to ensure the window is not transparent when theme transparency is selected
         .frame(make_frame_solid_via_context(
             egui::Frame::window(&contexts.ctx_mut().expect("Egui context to exist").style()),
-            &contexts.ctx_mut().expect("Egui context to exist"),
+            contexts.ctx_mut().expect("Egui context to exist"),
         ))
         .show(contexts.ctx_mut().expect("Egui context to exist"), |ui| {
             ui.horizontal(|ui| {
@@ -92,7 +92,7 @@ pub fn add_entity_ui(
                             if let GraniteTypes::Unknown(_) = *entity_type {
                                 continue;
                             }
-                            if ui.button(&entity_type.type_name()).clicked() {
+                            if ui.button(entity_type.type_name()).clicked() {
                                 entity_add_request.write(UserRequestGraniteTypeViaPopup {
                                     class: entity_type.clone(),
                                 });

--- a/crates/bevy_granite_editor/src/interface/popups/help_ui.rs
+++ b/crates/bevy_granite_editor/src/interface/popups/help_ui.rs
@@ -30,7 +30,7 @@ pub fn help_ui(
         .anchor(egui::Align2::CENTER_CENTER, egui::Vec2::ZERO)
         .frame(make_frame_solid_via_context(
             egui::Frame::window(&contexts.ctx_mut().expect("Egui context to exist").style()),
-            &contexts.ctx_mut().expect("Egui context to exist"),
+            contexts.ctx_mut().expect("Egui context to exist"),
         ))
         .show(contexts.ctx_mut().expect("Egui context to exist"), |ui| {
             ui.vertical(|ui| {

--- a/crates/bevy_granite_editor/src/interface/popups/relationship_ui.rs
+++ b/crates/bevy_granite_editor/src/interface/popups/relationship_ui.rs
@@ -26,7 +26,7 @@ pub fn relationship_ui(
         // call this to ensure the window is not transparent when theme transparency is selected
         .frame(make_frame_solid_via_context(
             egui::Frame::window(&contexts.ctx_mut().expect("Egui context to exist").style()),
-            &contexts.ctx_mut().expect("Egui context to exist"),
+            contexts.ctx_mut().expect("Egui context to exist"),
         ))
         .show(contexts.ctx_mut().expect("Egui context to exist"), |ui| {
             ui.vertical(|ui| {

--- a/crates/bevy_granite_editor/src/interface/shared/widgets/combobox.rs
+++ b/crates/bevy_granite_editor/src/interface/shared/widgets/combobox.rs
@@ -50,7 +50,7 @@ impl SelectableItem for EditableMaterial {
     }
 
     fn group_key(&self) -> String {
-        if self.path == "" || self.path == "None" {
+        if self.path.is_empty() || self.path == "None" {
             "materials/internal".to_string()
         } else if let Some(last_separator) = self.path.rfind('/') {
             self.path[..last_separator].to_string()
@@ -156,7 +156,7 @@ fn render_popup_content<T: SelectableItem>(
     for item in filtered_items.iter() {
         grouped_items
             .entry(item.group_key())
-            .or_insert_with(Vec::new)
+            .or_default()
             .push(*item);
     }
 

--- a/crates/bevy_granite_editor/src/interface/tabs/debug/system.rs
+++ b/crates/bevy_granite_editor/src/interface/tabs/debug/system.rs
@@ -37,7 +37,7 @@ pub fn update_debug_tab_ui_system(
                     let spawned_from = spawn_source_query
                         .get(active_entity)
                         .ok()
-                        .map(|s| s.0.clone());
+                        .map(|s| s.to_string());
 
                     ActiveObjectDetails {
                         entity: Some(active_entity),

--- a/crates/bevy_granite_editor/src/interface/tabs/entity_editor/data.rs
+++ b/crates/bevy_granite_editor/src/interface/tabs/entity_editor/data.rs
@@ -1,8 +1,10 @@
-use super::widgets::{ EntityIdentityData, EntityRegisteredData, EntityGlobalTransformData,
-    MaterialTab
+use std::borrow::Cow;
+
+use super::widgets::{
+    EntityGlobalTransformData, EntityIdentityData, EntityRegisteredData, MaterialTab,
 };
 use bevy::prelude::Entity;
-use bevy_granite_core::{AvailableEditableMaterials, NewEditableMaterial, ComponentEditor};
+use bevy_granite_core::{AvailableEditableMaterials, ComponentEditor, NewEditableMaterial};
 
 #[derive(PartialEq, Clone)]
 pub struct EntityEditorTabData {
@@ -13,7 +15,7 @@ pub struct EntityEditorTabData {
     pub global_transform_data: EntityGlobalTransformData,
     pub registered_data: EntityRegisteredData,
     pub component_editor: Option<ComponentEditor>,
-    pub registered_type_names: Vec<String>, // Parity with the PostStartup bevy resource
+    pub registered_type_names: Vec<Cow<'static, str>>, // Parity with the PostStartup bevy resource
     pub material_builder_open: bool,
     pub material_to_build: NewEditableMaterial,
     pub surface_collapsed_state: bool,

--- a/crates/bevy_granite_editor/src/interface/tabs/entity_editor/widgets/component_editor.rs
+++ b/crates/bevy_granite_editor/src/interface/tabs/entity_editor/widgets/component_editor.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::interface::{
     shared::widgets::combobox::component_selector_combo, tabs::EntityEditorTabData,
 };
@@ -112,21 +114,21 @@ fn display_add_registered_component(
     ui: &mut egui::Ui,
     component_changed: &mut bool,
     registered_add_request: &mut Option<String>,
-    registered_type_names: Vec<String>,
+    registered_type_names: Vec<Cow<'static, str>>,
     existing_components: &[ReflectedComponent],
     search_filter: &mut String,
 ) {
     let large_spacing = crate::UI_CONFIG.large_spacing;
     // Create a set of existing component type names for fast lookup
-    let existing_type_names: std::collections::HashSet<&String> = existing_components
+    let existing_type_names: std::collections::HashSet<Cow<'static, str>> = existing_components
         .iter()
-        .map(|comp| &comp.type_name)
+        .map(|comp| comp.type_name.clone())
         .collect();
 
     // Filter out components that are already on the entity
     let available_components: Vec<_> = registered_type_names
         .iter()
-        .filter(|name| !existing_type_names.contains(name))
+        .filter(|name| !existing_type_names.contains(name.as_ref()))
         .cloned()
         .collect();
 

--- a/crates/bevy_granite_editor/src/interface/tabs/node_tree/system.rs
+++ b/crates/bevy_granite_editor/src/interface/tabs/node_tree/system.rs
@@ -5,7 +5,7 @@ use bevy::ecs::query::Has;
 use bevy::ecs::system::Commands;
 use bevy::{
     ecs::query::{Changed, Or},
-    prelude::{ChildOf, Entity, Event, EventWriter, Name, Query, ResMut, With, Without},
+    prelude::{ChildOf, Entity, Event, EventWriter, Name, Query, ResMut, With},
 };
 use bevy_granite_core::{GraniteType, IdentityData, TreeHiddenEntity};
 use bevy_granite_gizmos::selection::events::EntityEvent;
@@ -329,11 +329,7 @@ fn detect_changes<'a>(
 ) -> (bool, bool, bool) {
     use std::collections::HashSet;
 
-    let current_entities: HashSet<Entity> = hierarchy_query
-        .clone()
-        .into_iter()
-        .map(|(e, _, _, _)| e)
-        .collect();
+    let current_entities: HashSet<Entity> = hierarchy_query.clone().map(|(e, _, _, _)| e).collect();
     let existing_entities: HashSet<Entity> =
         data.hierarchy.iter().map(|entry| entry.entity).collect();
 

--- a/crates/bevy_granite_editor/src/viewport/camera/system.rs
+++ b/crates/bevy_granite_editor/src/viewport/camera/system.rs
@@ -5,7 +5,7 @@ use crate::{
     viewport::camera::{handle_movement, handle_zoom, rotate_camera_towards},
 };
 use bevy::{
-    asset::{Assets, Handle},
+    asset::Assets,
     ecs::entity::Entity,
     input::mouse::{MouseMotion, MouseWheel},
     prelude::{

--- a/crates/bevy_granite_editor/src/viewport/debug/lights.rs
+++ b/crates/bevy_granite_editor/src/viewport/debug/lights.rs
@@ -4,7 +4,6 @@ use bevy::{
     color::Color,
     ecs::{entity::Entity, system::Query},
     gizmos::gizmos::Gizmos,
-    math::Dir3,
     pbr::{DirectionalLight, PointLight},
     prelude::{Res, With},
     transform::components::GlobalTransform,

--- a/crates/bevy_granite_editor/src/viewport/debug/selection.rs
+++ b/crates/bevy_granite_editor/src/viewport/debug/selection.rs
@@ -6,7 +6,7 @@ use bevy::{
     ecs::{entity::Entity, system::Query},
     gizmos::gizmos::Gizmos,
     math::Vec3,
-    prelude::{Assets, Handle, Mesh, Res, With},
+    prelude::{Assets, Mesh, Res, With},
     render::mesh::Mesh3d,
     transform::components::GlobalTransform,
 };

--- a/crates/bevy_granite_editor/src/viewport/icons/spawning.rs
+++ b/crates/bevy_granite_editor/src/viewport/icons/spawning.rs
@@ -1,4 +1,4 @@
-use super::{IconBundle, IconEntity};
+use super::IconEntity;
 use crate::{editor_state::EditorState, viewport::config::VisualizationConfig};
 use bevy::{
     pbr::{MeshMaterial3d, NotShadowCaster, NotShadowReceiver, StandardMaterial},
@@ -43,13 +43,13 @@ pub fn spawn_icon_entities_system(
             let handle = class.get_icon_handle();
             let name = class.type_name() + "_icon";
 
-            if handle.is_some() {
+            if let Some(handle) = handle {
                 spawn_icon_for_entity(
                     &mut commands,
                     &mut meshes,
                     &mut materials,
                     entity,
-                    handle.unwrap(),
+                    handle,
                     name,
                     config,
                 );
@@ -74,7 +74,7 @@ fn spawn_icon_for_entity(
     // Create material with the embedded icon texture
     let material_handle = materials.add(StandardMaterial {
         base_color_texture: Some(texture_handle),
-        base_color: bevy::color::Color::srgb_from_array(config.icon_color).into(),
+        base_color: bevy::color::Color::srgb_from_array(config.icon_color),
         unlit: true,
         alpha_mode: AlphaMode::Mask(0.5), // Use alpha cutout for icons
         cull_mode: None,

--- a/crates/bevy_granite_editor/src/viewport/icons/updating.rs
+++ b/crates/bevy_granite_editor/src/viewport/icons/updating.rs
@@ -4,7 +4,7 @@ use bevy::{
     color::Color,
     math::Vec3,
     pbr::{MeshMaterial3d, StandardMaterial},
-    prelude::{Assets, Entity, Handle, Query, Res, ResMut, Transform, With, Without},
+    prelude::{Assets, Entity, Query, Res, ResMut, Transform, With, Without},
     render::view::Visibility,
     transform::components::GlobalTransform,
 };

--- a/crates/bevy_granite_gizmos/src/gizmos/manager.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/manager.rs
@@ -1,7 +1,7 @@
 use super::{
-    despawn_rotate_gizmo, spawn_rotate_gizmo, spawn_transform_gizmo, DespawnGizmoEvent, GizmoType,
-    LastSelectedGizmo, RotateGizmo, RotateGizmoParent, SelectedGizmo, SpawnGizmoEvent,
-    TransformGizmo, TransformGizmoParent,
+    spawn_rotate_gizmo, spawn_transform_gizmo, DespawnGizmoEvent, GizmoType, LastSelectedGizmo,
+    RotateGizmo, RotateGizmoParent, SelectedGizmo, SpawnGizmoEvent, TransformGizmo,
+    TransformGizmoParent,
 };
 use crate::selection::ActiveSelection;
 use bevy::prelude::{

--- a/crates/bevy_granite_gizmos/src/gizmos/rotate/drag.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/rotate/drag.rs
@@ -407,7 +407,6 @@ pub fn debug_handle_rotate_dragging<const AXIS: char>(
 ) {
     let gizmo_distance_scale = selected.speed_scale;
     let free_rotate_speed = 0.3 * gizmo_distance_scale;
-    let locked_rotate_speed = 1.15 * gizmo_distance_scale;
 
     let gizmo_axis = match AXIS {
         'X' | 'x' => GizmoAxis::X,

--- a/crates/bevy_granite_gizmos/src/gizmos/transform/drag.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/transform/drag.rs
@@ -156,7 +156,7 @@ pub fn drag_transform_gizmo(
             target_transform.translation.y = snap_gizmo(hit.y, gizmo_snap.transform_value);
         }
         (GizmoAxis::All, _) => {
-            let Some(click_distance) = click_ray.intersect_plane(
+            let Some(_click_distance) = click_ray.intersect_plane(
                 target_transform.translation,
                 bevy::math::primitives::InfinitePlane3d::new(camera_transform.forward()),
             ) else {

--- a/crates/bevy_granite_gizmos/src/selection/ray.rs
+++ b/crates/bevy_granite_gizmos/src/selection/ray.rs
@@ -1,7 +1,7 @@
 use bevy::{
     ecs::query::Changed,
     picking::hover::PickingInteraction,
-    prelude::{Entity, Name, Query, Res, ResMut, Resource, Vec3},
+    prelude::{Entity, Name, Query, Resource, Vec3},
 };
 use bevy_granite_core::IconProxy;
 use bevy_granite_logging::{

--- a/crates/bevy_granite_gizmos/src/ui/plugin.rs
+++ b/crates/bevy_granite_gizmos/src/ui/plugin.rs
@@ -1,7 +1,7 @@
 use super::editor_gizmos_ui;
 use crate::is_gizmos_active;
 use bevy::{
-    app::{App, Plugin, Update},
+    app::{App, Plugin},
     ecs::schedule::IntoScheduleConfigs,
 };
 use bevy_egui::EguiPrimaryContextPass;

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -45,7 +45,6 @@ fn main() {
             ..Default::default()
         })
         .add_systems(Startup, setup)
-        .add_systems(Update, print_cube_color)
         .run();
 }
 
@@ -53,40 +52,4 @@ fn setup(mut open_event: EventWriter<RequestLoadEvent>) {
     // Event to load a world (.scene)
     // When finished loading it will send a `WorldLoadSuccessEvent` with the loaded world str name
     open_event.write(RequestLoadEvent(STARTING_WORLD.to_string()));
-}
-
-fn test_cube(
-    mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
-    mut materials: ResMut<Assets<StandardMaterial>>,
-) {
-    commands.spawn((
-        Camera3d::default(),
-        Transform::from_translation(Vec3::ONE * 5.).looking_at(Vec3::ZERO, Vec3::Y),
-    ));
-    // Create a simple cube with a material
-    let mesh = meshes.add(Cuboid::from_length(1.));
-    let material = materials.add(StandardMaterial {
-        base_color: Color::WHITE,
-        ..Default::default()
-    });
-
-    commands.spawn((Mesh3d(mesh), MeshMaterial3d(material)));
-}
-
-fn print_cube_color(
-    input: Res<ButtonInput<KeyCode>>,
-    query: Query<&MeshMaterial3d<StandardMaterial>>,
-    materials: Res<Assets<StandardMaterial>>,
-) {
-    if !input.just_pressed(KeyCode::F12) {
-        return;
-    }
-    for mesh_material in query.iter() {
-        if let Some(material) = materials.get(&mesh_material.0) {
-            println!("Cube color: {:?}", material.base_color);
-        } else {
-            println!("Material not found for handle: {:?}", mesh_material.0);
-        }
-    }
 }


### PR DESCRIPTION
We should always use &str when possible, instead of passing Owned Strings around.
I am using Vec<Cow<'static, str>> to replace Vec<String> since it is a drop-in replacement, and I am unsure if there is a reason we might need not static str, but in future I would like to replace them with Vec<'static str>.

When going over the code, I don't see any reason to keep a vector of strings over something like a vector of type IDs and a copy of the TypeRegistry to look up type info as needed.