### PR TITLE
implement safe entity despawning to prevent crashes

### DIFF
--- a/crates/bevy_granite_gizmos/src/gizmos/mod.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/mod.rs
@@ -75,6 +75,12 @@ impl GizmoOf {
 #[relationship_target(relationship = GizmoOf)]
 pub struct Gizmos(Vec<Entity>);
 
+impl Gizmos {
+    pub fn entities(&self) -> &[Entity] {
+        &self.0
+    }
+}
+
 use bevy_granite_core::EditorIgnore;
 pub use distance_scaling::scale_gizmo_by_camera_distance_system;
 pub use events::{

--- a/crates/bevy_granite_gizmos/src/selection/mod.rs
+++ b/crates/bevy_granite_gizmos/src/selection/mod.rs
@@ -23,10 +23,17 @@ impl ActiveSelection {
             .send(SpawnGizmoEvent(ctx.entity));
     }
     fn on_remove(mut world: DeferredWorld, ctx: HookContext) {
-        world
-            .commands()
-            .entity(ctx.entity)
-            .despawn_related::<crate::gizmos::Gizmos>();
+        if let Ok(_entity_commands) = world.commands().get_entity(ctx.entity) {
+            if let Some(gizmos) = world.entity(ctx.entity).get::<crate::gizmos::Gizmos>() {
+                let targets: Vec<_> = gizmos.entities().iter().copied().collect();
+                let mut commands = world.commands();
+                for target in targets {
+                    if let Ok(mut target_commands) = commands.get_entity(target) {
+                        target_commands.despawn();
+                    }
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Collect gizmo target entities and despawn them safely in selection cleanup. Related to #21 
