### PR TITLE
Despawn gizmo on change

### DIFF
--- a/crates/bevy_granite_gizmos/src/gizmos/manager.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/manager.rs
@@ -1,7 +1,7 @@
 use super::{
-    spawn_rotate_gizmo, spawn_transform_gizmo, DespawnGizmoEvent, GizmoType, LastSelectedGizmo,
-    RotateGizmo, RotateGizmoParent, SelectedGizmo, SpawnGizmoEvent, TransformGizmo,
-    TransformGizmoParent,
+    despawn_rotate_gizmo, despawn_transform_gizmo, spawn_rotate_gizmo, spawn_transform_gizmo,
+    DespawnGizmoEvent, GizmoType, LastSelectedGizmo, RotateGizmo, RotateGizmoParent, SelectedGizmo,
+    SpawnGizmoEvent, TransformGizmo, TransformGizmoParent,
 };
 use crate::selection::ActiveSelection;
 use bevy::prelude::{
@@ -42,6 +42,14 @@ pub fn gizmo_events(
                 &mut materials,
                 &mut meshes,
             );
+        }
+    }
+
+    for DespawnGizmoEvent(gizmo_type) in despawn_events.read() {
+        if matches!(gizmo_type, GizmoType::Transform) {
+            despawn_transform_gizmo(&mut commands, &mut transform_gizmo_query);
+        } else if matches!(gizmo_type, GizmoType::Rotate) {
+            despawn_rotate_gizmo(&mut commands, &mut rotate_gizmo_query);
         }
     }
 }

--- a/crates/bevy_granite_gizmos/src/gizmos/mod.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/mod.rs
@@ -95,6 +95,6 @@ pub use rotate::{
     RotateGizmoParent,
 };
 pub use transform::{
-    draw_axis_line, spawn_transform_gizmo, PreviousTransformGizmo, TransformGizmo,
-    TransformGizmoParent,
+    despawn_transform_gizmo, draw_axis_line, spawn_transform_gizmo, PreviousTransformGizmo,
+    TransformGizmo, TransformGizmoParent,
 };

--- a/crates/bevy_granite_gizmos/src/gizmos/rotate/gizmo.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/rotate/gizmo.rs
@@ -28,7 +28,7 @@ pub struct PreviousTransformGizmo {
     pub entity: Option<Entity>,
 }
 
-const GIZMO_SCALE: f32 = 0.9;
+const GIZMO_SCALE: f32 = 0.45;
 const ROTATE_INNER_RADIUS: f32 = 0.12 * GIZMO_SCALE; // middle sphere of gizmo (free rotate)
 const ROTATE_VISUAL_RADIUS: f32 = 0.64 * GIZMO_SCALE; // middle sphere of gizmo (visual)
 const RING_MESH_HASH: &str = "3f6f4c2a-6e36-4ccf-81c4-f343f83c5f80"; // constantly random - doesnt matter the value

--- a/crates/bevy_granite_gizmos/src/gizmos/transform/gizmo.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/transform/gizmo.rs
@@ -1,5 +1,5 @@
 use bevy::{
-    ecs::hierarchy::ChildOf,
+    ecs::hierarchy::{ChildOf, Children},
     pbr::{MeshMaterial3d, NotShadowCaster, NotShadowReceiver},
     prelude::{
         AlphaMode, Assets, Color, Commands, Component, Cone, Cylinder, Entity, GlobalTransform,
@@ -243,6 +243,21 @@ fn build_axis_cylinder(
             TransformGizmo::Plane,
             GizmoMesh,
         ));
+}
+
+pub fn despawn_transform_gizmo(
+    commands: &mut Commands,
+    query: &mut Query<(Entity, &TransformGizmo, &Children)>,
+) {
+    for (entity, _, _) in query.iter() {
+        commands.entity(entity).despawn();
+        log!(
+            LogType::Editor,
+            LogLevel::Info,
+            LogCategory::Entity,
+            "Despawned Transform Gizmo"
+        );
+    }
 }
 
 fn plane_translation(axis: GizmoAxis) -> Vec3 {


### PR DESCRIPTION
Properly handle despawning of old gizmo#23. This is a stop gap solution until global gizmo state is implemented. Meaning no spawn/despawn, and no gizmos as children, just visibility.