### PR TITLE
:bug: Reintroduces Duplicate on Move

### DIFF
--- a/crates/bevy_granite_gizmos/src/gizmos/transform/drag.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/transform/drag.rs
@@ -2,13 +2,16 @@ use super::TransformGizmo;
 use crate::{
     gizmos::{GizmoOf, GizmoSnap},
     input::GizmoAxis,
-    GizmoCamera,
+    GizmoCamera, RequestDuplicateEntityEvent,
 };
 use bevy::{
     asset::Assets,
-    ecs::{component::Component, hierarchy::ChildOf, observer::Trigger, system::Commands},
+    ecs::{
+        component::Component, event::EventWriter, hierarchy::ChildOf, observer::Trigger,
+        system::Commands,
+    },
     gizmos::{retained::Gizmo, GizmoAsset},
-    picking::events::{Drag, Pointer, Pressed},
+    picking::events::{Drag, DragStart, Pointer, Pressed},
     prelude::{Entity, GlobalTransform, Query, Res, ResMut, Transform, Vec3, With},
 };
 use bevy_granite_core::UserInput;
@@ -193,7 +196,8 @@ pub fn drag_transform_gizmo(
 
             if let Ok(parent) = parents.get(*target) {
                 if let Ok(parent_global) = global_transforms.get(parent.parent()) {
-                    let parent_rotation_inv = parent_global.to_scale_rotation_translation().1.inverse();
+                    let parent_rotation_inv =
+                        parent_global.to_scale_rotation_translation().1.inverse();
                     let world_delta = Vec3::new(0.0, delta_y, delta_z);
                     let parent_local_delta = parent_rotation_inv * world_delta;
                     target_transform.translation += parent_local_delta;
@@ -220,7 +224,8 @@ pub fn drag_transform_gizmo(
 
             if let Ok(parent) = parents.get(*target) {
                 if let Ok(parent_global) = global_transforms.get(parent.parent()) {
-                    let parent_rotation_inv = parent_global.to_scale_rotation_translation().1.inverse();
+                    let parent_rotation_inv =
+                        parent_global.to_scale_rotation_translation().1.inverse();
                     let world_delta = Vec3::new(delta_x, 0.0, delta_z);
                     let parent_local_delta = parent_rotation_inv * world_delta;
                     target_transform.translation += parent_local_delta;
@@ -247,7 +252,8 @@ pub fn drag_transform_gizmo(
 
             if let Ok(parent) = parents.get(*target) {
                 if let Ok(parent_global) = global_transforms.get(parent.parent()) {
-                    let parent_rotation_inv = parent_global.to_scale_rotation_translation().1.inverse();
+                    let parent_rotation_inv =
+                        parent_global.to_scale_rotation_translation().1.inverse();
                     let world_delta = Vec3::new(delta_x, delta_y, 0.0);
                     let parent_local_delta = parent_rotation_inv * world_delta;
                     target_transform.translation += parent_local_delta;
@@ -275,7 +281,8 @@ pub fn drag_transform_gizmo(
 
             if let Ok(parent) = parents.get(*target) {
                 if let Ok(parent_global) = global_transforms.get(parent.parent()) {
-                    let parent_rotation_inv = parent_global.to_scale_rotation_translation().1.inverse();
+                    let parent_rotation_inv =
+                        parent_global.to_scale_rotation_translation().1.inverse();
                     let parent_local_delta = parent_rotation_inv * snapped_delta;
                     target_transform.translation += parent_local_delta;
                 } else {
@@ -293,6 +300,30 @@ pub fn drag_transform_gizmo(
             camera_transform.translation += delta;
         }
     }
+}
+
+pub fn dragstart_transform_gizmo(
+    event: Trigger<Pointer<DragStart>>,
+    targets: Query<&GizmoOf>,
+    parents: Query<&ChildOf>,
+    gizmo_data: Query<(&GizmoAxis, &TransformGizmo)>,
+    user_input: Res<UserInput>,
+    mut commands: Commands,
+    mut dispatch: EventWriter<RequestDuplicateEntityEvent>,
+) {
+    if user_input.mouse_middle.any || !user_input.shift_left.pressed {
+        return;
+    }
+    let Ok(_) = gizmo_data.get(event.target) else {
+        return;
+    };
+    let Ok(GizmoOf(target)) = targets.get(event.target) else {
+        return;
+    };
+    log!("Attempting Drag Duplicate");
+    dispatch.write(RequestDuplicateEntityEvent {
+        entity: target.clone(),
+    });
 }
 
 fn snap_gizmo(value: f32, inc: f32) -> f32 {

--- a/crates/bevy_granite_gizmos/src/gizmos/transform/drag.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/transform/drag.rs
@@ -305,10 +305,8 @@ pub fn drag_transform_gizmo(
 pub fn dragstart_transform_gizmo(
     event: Trigger<Pointer<DragStart>>,
     targets: Query<&GizmoOf>,
-    parents: Query<&ChildOf>,
     gizmo_data: Query<(&GizmoAxis, &TransformGizmo)>,
     user_input: Res<UserInput>,
-    mut commands: Commands,
     mut dispatch: EventWriter<RequestDuplicateEntityEvent>,
 ) {
     if user_input.mouse_middle.any || !user_input.shift_left.pressed {

--- a/crates/bevy_granite_gizmos/src/gizmos/transform/gizmo.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/transform/gizmo.rs
@@ -156,7 +156,8 @@ fn build_gizmo_sphere(
             GizmoOf(root),
             ChildOf(parent),
         ))
-        .observe(super::drag::drag_transform_gizmo);
+        .observe(super::drag::drag_transform_gizmo)
+        .observe(super::drag::dragstart_transform_gizmo);
 }
 
 fn build_axis_cylinder(
@@ -211,6 +212,7 @@ fn build_axis_cylinder(
         .insert(GizmoMesh)
         .insert(ChildOf(parent))
         .observe(super::drag::drag_transform_gizmo)
+        .observe(super::drag::dragstart_transform_gizmo)
         .with_child((
             Mesh3d(cone_mesh),
             MeshMaterial3d(material.clone()),

--- a/crates/bevy_granite_gizmos/src/selection/duplicate.rs
+++ b/crates/bevy_granite_gizmos/src/selection/duplicate.rs
@@ -1,5 +1,8 @@
 use super::{RequestDuplicateAllSelectionEvent, RequestDuplicateEntityEvent};
-use crate::{gizmos::GizmoChildren, selection::Selected};
+use crate::{
+    gizmos::{GizmoChildren, Gizmos},
+    selection::Selected,
+};
 use bevy::{
     asset::{Assets, Handle},
     ecs::{
@@ -237,6 +240,7 @@ fn copy_components_safe(
     let mut skip_components = vec![
         std::any::TypeId::of::<ChildOf>(),
         std::any::TypeId::of::<Children>(),
+        std::any::TypeId::of::<Gizmos>(),
     ];
 
     // Things like rectangle brushes need unique handles, as we directly edit the vert data in editor


### PR DESCRIPTION
Addresses regression #19

Kept it simple.

This leaves the duplicate in place and continues with the transform of the original. I'm not entirely sure the behavior of the eventreader and command queuing to be sure of the risk of partially moving the original before the duplicate happens, but for now it works.