### PR TITLE
Fix unique handles when duplicating

### DIFF
--- a/crates/bevy_granite_gizmos/src/selection/duplicate.rs
+++ b/crates/bevy_granite_gizmos/src/selection/duplicate.rs
@@ -4,7 +4,7 @@ use crate::{
     selection::Selected,
 };
 use bevy::{
-    asset::{Assets, Handle},
+    asset::Assets,
     ecs::{
         entity::Entity,
         query::With,
@@ -245,7 +245,13 @@ fn copy_components_safe(
 
     // Things like rectangle brushes need unique handles, as we directly edit the vert data in editor
     if needs_unique {
-        skip_components.push(std::any::TypeId::of::<Handle<Mesh>>());
+        log!(
+            LogType::Editor,
+            LogLevel::Info,
+            LogCategory::Entity,
+            "Requesting unique handle"
+        );
+        skip_components.push(std::any::TypeId::of::<Mesh3d>());
     }
 
     for &type_id in component_type_ids {
@@ -288,7 +294,8 @@ fn copy_components_safe(
                     LogType::Editor,
                     LogLevel::Warning,
                     LogCategory::Entity,
-                    "Source entity {:?} does not exist, skipping component {:?}.",
+                    "Error: {:?} Source entity {:?} does not exist, skipping component {:?}.",
+                    e,
                     source_entity,
                     type_id
                 );

--- a/crates/bevy_granite_gizmos/src/selection/duplicate.rs
+++ b/crates/bevy_granite_gizmos/src/selection/duplicate.rs
@@ -13,7 +13,7 @@ use bevy::{
     prelude::{AppTypeRegistry, ChildOf, Children, EventReader, ReflectComponent, Res, World},
     render::mesh::{Mesh, Mesh3d},
 };
-use bevy_granite_core::{entities::GraniteType, HasRuntimeData, IconProxy, IdentityData};
+use bevy_granite_core::{entities::GraniteType, EditorIgnore, HasRuntimeData, IconProxy, IdentityData};
 use bevy_granite_logging::{
     config::{LogCategory, LogLevel, LogType},
     log,
@@ -195,10 +195,14 @@ fn collect_entity_info(world: &World, entity: Entity) -> Option<EntityInfo> {
                 .filter(|&child| {
                     world
                         .get_entity(child)
-                        // Do NOT include GizmoParent or IconProxy in duplication
+                        // Do NOT include GizmoChildren, IconProxy, or any gizmo entities in duplication
                         .map(|entity_ref| {
                             !entity_ref.contains::<GizmoChildren>()
                                 && !entity_ref.contains::<IconProxy>()
+                                && !entity_ref
+                                    .get::<EditorIgnore>()
+                                    .map(|ignore| ignore.contains(EditorIgnore::GIZMO))
+                                    .unwrap_or(false)
                         })
                         .unwrap_or(false)
                 })
@@ -240,7 +244,6 @@ fn copy_components_safe(
     let mut skip_components = vec![
         std::any::TypeId::of::<ChildOf>(),
         std::any::TypeId::of::<Children>(),
-        std::any::TypeId::of::<Gizmos>(),
     ];
 
     // Things like rectangle brushes need unique handles, as we directly edit the vert data in editor
@@ -319,12 +322,10 @@ fn copy_components_safe(
 
         // Special handling for IdentityData to generate a new UUID
         if type_id == std::any::TypeId::of::<IdentityData>() {
-            // Get source identity data first
             if let Some(source_identity) = world.get::<IdentityData>(source_entity) {
                 let mut new_identity = source_identity.clone();
                 new_identity.uuid = Uuid::new_v4(); // Generate new UUID for the duplicate
 
-                // Now insert the new identity data
                 if let Ok(mut target_ref) = world.get_entity_mut(target_entity) {
                     target_ref.insert(new_identity);
                 }


### PR DESCRIPTION
When duplicating, some types need a unique mesh handle. Bevy API had changed from Mesh to Mesh3d.