### PR TITLE
UI callable events

### DIFF
--- a/crates/bevy_granite_core/src/events.rs
+++ b/crates/bevy_granite_core/src/events.rs
@@ -1,4 +1,5 @@
 use bevy::{prelude::Event, transform::components::Transform};
+use bevy_granite_macros::ui_callable_events;
 
 use crate::entities::SaveSettings;
 
@@ -31,3 +32,5 @@ pub struct RequestDespawnSerializableEntities;
 
 #[derive(Event)]
 pub struct RequestDespawnBySource(pub String);
+
+

--- a/crates/bevy_granite_core/src/lib.rs
+++ b/crates/bevy_granite_core/src/lib.rs
@@ -30,6 +30,16 @@ pub use assets::{
     RequiredMaterialData, RequiredMaterialDataMut, StandardMaterialDef,
 };
 pub use bevy_granite_macros::register_editor_components;
+
+// Marker trait for UI callable events
+pub trait UICallableEventMarker {}
+
+// Trait for providing event information to UI
+pub trait UICallableEventProvider {
+    fn get_struct_name() -> &'static str;
+    fn get_event_names() -> &'static [&'static str];
+}
+
 pub use entities::{
     BridgeTag, Camera3D, ClassCategory, ComponentEditor, DirLight, EditorIgnore,
     GraniteEditorSerdeEntity, GraniteType, GraniteTypes, HasRuntimeData, IdentityData, MainCamera,
@@ -39,8 +49,8 @@ pub use entities::{
 };
 pub use events::{
     CollectRuntimeDataEvent, RequestDespawnBySource, RequestDespawnSerializableEntities,
-    RequestLoadEvent, RequestReloadEvent, RequestSaveEvent, 
-    RuntimeDataReadyEvent, WorldLoadSuccessEvent, WorldSaveSuccessEvent,
+    RequestLoadEvent, RequestReloadEvent, RequestSaveEvent, RuntimeDataReadyEvent,
+    WorldLoadSuccessEvent, WorldSaveSuccessEvent,
 };
 pub use setup::RegisteredTypeNames;
 pub use shared::{

--- a/crates/bevy_granite_editor/Cargo.toml
+++ b/crates/bevy_granite_editor/Cargo.toml
@@ -19,9 +19,11 @@ bevy_granite_gizmos = { path = "../bevy_granite_gizmos"}
 bevy_granite_core = { path = "../bevy_granite_core"}
 bevy_granite_logging = { path = "../bevy_granite_logging"}
 bevy_granite_expose = { path = "../bevy_granite_expose" }
+bevy_granite_macros = { path = "../bevy_granite_macros" }
 
 egui_dock = {version = "0.17.0", features = ["serde"]}
 webbrowser = "1.0.5"
+inventory = "0.3.19"
 
 [lib]
 name = "bevy_granite_editor"

--- a/crates/bevy_granite_editor/Cargo.toml
+++ b/crates/bevy_granite_editor/Cargo.toml
@@ -23,7 +23,6 @@ bevy_granite_macros = { path = "../bevy_granite_macros" }
 
 egui_dock = {version = "0.17.0", features = ["serde"]}
 webbrowser = "1.0.5"
-inventory = "0.3.19"
 
 [lib]
 name = "bevy_granite_editor"

--- a/crates/bevy_granite_editor/src/interface/layout/top_bar.rs
+++ b/crates/bevy_granite_editor/src/interface/layout/top_bar.rs
@@ -12,6 +12,7 @@ use crate::{
         popups::PopupType,
         tabs::{
             debug::ui::DebugTabData, log::LogTabData, EditorSettingsTabData, EntityEditorTabData,
+            EventsTabData,
         },
         EditorEvents, NodeTreeTabData,
     },
@@ -164,6 +165,7 @@ pub fn top_bar_ui(
                 }
             });
             ui.menu_button("Panels", |ui| {
+                // Entity Editor
                 if !side_dock
                     .dock_state
                     .iter_all_tabs()
@@ -177,6 +179,7 @@ pub fn top_bar_ui(
                     ui.close();
                 }
 
+                // Node tree
                 if !side_dock
                     .dock_state
                     .iter_all_tabs()
@@ -190,6 +193,7 @@ pub fn top_bar_ui(
                     ui.close();
                 }
 
+                // Settings
                 if !side_dock
                     .dock_state
                     .iter_all_tabs()
@@ -203,6 +207,7 @@ pub fn top_bar_ui(
                     ui.close();
                 }
 
+                // Log
                 if !bottom_dock
                     .dock_state
                     .iter_all_tabs()
@@ -216,6 +221,7 @@ pub fn top_bar_ui(
                     ui.close();
                 }
 
+                // Debug
                 if !bottom_dock
                     .dock_state
                     .iter_all_tabs()
@@ -224,6 +230,20 @@ pub fn top_bar_ui(
                 {
                     let tab = BottomTab::Debug {
                         data: DebugTabData::default(),
+                    };
+                    bottom_dock.dock_state.push_to_focused_leaf(tab);
+                    ui.close();
+                }
+
+                // Event
+                if !bottom_dock
+                    .dock_state
+                    .iter_all_tabs()
+                    .any(|(_, tab)| matches!(tab, BottomTab::Events { .. }))
+                    && ui.button("Events").clicked()
+                {
+                    let tab = BottomTab::Events {
+                        data: EventsTabData::default(),
                     };
                     bottom_dock.dock_state.push_to_focused_leaf(tab);
                     ui.close();

--- a/crates/bevy_granite_editor/src/interface/panels/bottom_panel.rs
+++ b/crates/bevy_granite_editor/src/interface/panels/bottom_panel.rs
@@ -3,7 +3,9 @@ use bevy_egui::egui;
 use egui_dock::{DockState, NodeIndex, TabViewer};
 use serde::{Deserialize, Serialize};
 
-use crate::interface::{tabs::{debug_tab_ui, log_tab_ui}, DebugTabData, LogTabData};
+use crate::interface::tabs::{
+    debug_tab_ui, events_tab_ui, log_tab_ui, DebugTabData, EventsTabData, LogTabData,
+};
 
 #[derive(Resource, Clone)]
 pub struct BottomDockState {
@@ -18,12 +20,17 @@ impl Default for BottomDockState {
         let debug_tab = BottomTab::Debug {
             data: DebugTabData::default(),
         };
+        let events_tab = BottomTab::Events {
+            data: EventsTabData::default(),
+        };
 
         let mut dock_state = DockState::new(vec![debug_tab]);
 
         let surface = dock_state.main_surface_mut();
 
-        let [_debug_node, _log_node] = surface.split_right(NodeIndex::root(), 0.1, vec![log_tab]);
+        let [_debug_node, remaining] =
+            surface.split_right(NodeIndex::root(), 0.33, vec![events_tab]);
+        let [_events_node, _log_node] = surface.split_right(remaining, 0.5, vec![log_tab]);
 
         Self { dock_state }
     }
@@ -39,6 +46,10 @@ pub enum BottomTab {
         #[serde(skip)]
         data: DebugTabData,
     },
+    Events {
+        #[serde(skip)]
+        data: EventsTabData,
+    },
 }
 
 #[derive(Resource)]
@@ -51,6 +62,7 @@ impl TabViewer for BottomTabViewer {
         match tab {
             BottomTab::Log { data, .. } => log_tab_ui(ui, data),
             BottomTab::Debug { data, .. } => debug_tab_ui(ui, data),
+            BottomTab::Events { data, .. } => events_tab_ui(ui, data),
         }
     }
 
@@ -58,6 +70,7 @@ impl TabViewer for BottomTabViewer {
         match tab {
             BottomTab::Log { .. } => "Log".into(),
             BottomTab::Debug { .. } => "Debug".into(),
+            BottomTab::Events { .. } => "Events".into(),
         }
     }
 }

--- a/crates/bevy_granite_editor/src/interface/plugin.rs
+++ b/crates/bevy_granite_editor/src/interface/plugin.rs
@@ -10,10 +10,10 @@ use super::{
     layout::dock_ui_system,
     popups::{handle_popup_requests_system, show_active_popups_system},
     tabs::{
-        handle_material_deletion_system, update_debug_tab_ui_system,
+        handle_material_deletion_system, send_queued_events_system, update_debug_tab_ui_system,
         update_editor_settings_tab_system, update_entity_editor_tab_system,
         update_entity_with_new_components_system, update_entity_with_new_identity_system,
-        update_entity_with_new_transform_system, update_log_tab_system,
+        update_entity_with_new_transform_system, update_events_tab_system, update_log_tab_system,
         update_material_handle_system, update_node_tree_tabs_system, RequestReparentEntityEvent,
     },
     BottomDockState, EntityUIDataCache, PopupState, SideDockState,
@@ -50,6 +50,7 @@ impl Plugin for InterfacePlugin {
             // need to rework
             .add_event::<RequestReparentEntityEvent>()
             .add_event::<RequestRemoveParentsFromEntities>()
+
             //
             // Register types
             // If you want to duplicate bevy data you must register the type
@@ -93,6 +94,7 @@ impl Plugin for InterfacePlugin {
                     update_editor_settings_tab_system,
                     update_log_tab_system,
                     update_debug_tab_ui_system,
+                    update_events_tab_system,
                     update_node_tree_tabs_system,
                 )
                     .chain()
@@ -101,6 +103,10 @@ impl Plugin for InterfacePlugin {
             .add_systems(
                 EguiPrimaryContextPass,
                 (show_active_popups_system, dock_ui_system).run_if(is_editor_active),
+            )
+            .add_systems(
+                Update,
+                send_queued_events_system.run_if(is_editor_active),
             );
     }
 }

--- a/crates/bevy_granite_editor/src/interface/plugin.rs
+++ b/crates/bevy_granite_editor/src/interface/plugin.rs
@@ -13,7 +13,7 @@ use super::{
         handle_material_deletion_system, send_queued_events_system, update_debug_tab_ui_system,
         update_editor_settings_tab_system, update_entity_editor_tab_system,
         update_entity_with_new_components_system, update_entity_with_new_identity_system,
-        update_entity_with_new_transform_system, update_events_tab_system, update_log_tab_system,
+        update_entity_with_new_transform_system, update_log_tab_system,
         update_material_handle_system, update_node_tree_tabs_system, RequestReparentEntityEvent,
     },
     BottomDockState, EntityUIDataCache, PopupState, SideDockState,
@@ -50,7 +50,6 @@ impl Plugin for InterfacePlugin {
             // need to rework
             .add_event::<RequestReparentEntityEvent>()
             .add_event::<RequestRemoveParentsFromEntities>()
-
             //
             // Register types
             // If you want to duplicate bevy data you must register the type
@@ -94,7 +93,6 @@ impl Plugin for InterfacePlugin {
                     update_editor_settings_tab_system,
                     update_log_tab_system,
                     update_debug_tab_ui_system,
-                    update_events_tab_system,
                     update_node_tree_tabs_system,
                 )
                     .chain()
@@ -104,9 +102,6 @@ impl Plugin for InterfacePlugin {
                 EguiPrimaryContextPass,
                 (show_active_popups_system, dock_ui_system).run_if(is_editor_active),
             )
-            .add_systems(
-                Update,
-                send_queued_events_system.run_if(is_editor_active),
-            );
+            .add_systems(Update, send_queued_events_system.run_if(is_editor_active));
     }
 }

--- a/crates/bevy_granite_editor/src/interface/tabs/events/mod.rs
+++ b/crates/bevy_granite_editor/src/interface/tabs/events/mod.rs
@@ -1,0 +1,5 @@
+pub mod ui;
+pub mod system;
+
+pub use ui::*;
+pub use system::*;

--- a/crates/bevy_granite_editor/src/interface/tabs/events/system.rs
+++ b/crates/bevy_granite_editor/src/interface/tabs/events/system.rs
@@ -1,39 +1,13 @@
-use crate::interface::BottomDockState;
 use bevy::prelude::*;
 use super::ui::{EVENT_REQUEST_QUEUE, EVENT_REGISTRY};
 
-pub fn update_events_tab_system(
-    mut bottom_dock_state: ResMut<BottomDockState>,
-) {
-    let tabs = &mut bottom_dock_state.dock_state.iter_all_tabs_mut();
-
-    for (_, tab) in tabs {
-        if let crate::interface::panels::BottomTab::Events { data: _data } = tab {
-            // Process any queued event requests
-            let mut queue = EVENT_REQUEST_QUEUE.lock().unwrap();
-            
-            if !queue.is_empty() {
-                println!("Processing {} event requests", queue.len());
-                
-                // For now, just log the events - actual sending will be handled by a separate exclusive system
-                for request in queue.drain(..) {
-                    println!("Event queued: {} from {}", request.event_name, request.struct_name);
-                }
-            }
-        }
-    }
-}
-
-// Separate exclusive system to actually send the events
 pub fn send_queued_events_system(world: &mut World) {
     let mut queue = EVENT_REQUEST_QUEUE.lock().unwrap();
     
     if !queue.is_empty() {
         let registry = EVENT_REGISTRY.lock().unwrap();
         
-        // Process each event request
         for request in queue.drain(..) {
-            // Find the matching event info and sender
             for event_info in registry.iter() {
                 if event_info.struct_name == request.struct_name {
                     if let Some(index) = event_info.event_names.iter().position(|&name| name == request.event_name) {

--- a/crates/bevy_granite_editor/src/interface/tabs/events/system.rs
+++ b/crates/bevy_granite_editor/src/interface/tabs/events/system.rs
@@ -1,0 +1,50 @@
+use crate::interface::BottomDockState;
+use bevy::prelude::*;
+use super::ui::{EVENT_REQUEST_QUEUE, EVENT_REGISTRY};
+
+pub fn update_events_tab_system(
+    mut bottom_dock_state: ResMut<BottomDockState>,
+) {
+    let tabs = &mut bottom_dock_state.dock_state.iter_all_tabs_mut();
+
+    for (_, tab) in tabs {
+        if let crate::interface::panels::BottomTab::Events { data: _data } = tab {
+            // Process any queued event requests
+            let mut queue = EVENT_REQUEST_QUEUE.lock().unwrap();
+            
+            if !queue.is_empty() {
+                println!("Processing {} event requests", queue.len());
+                
+                // For now, just log the events - actual sending will be handled by a separate exclusive system
+                for request in queue.drain(..) {
+                    println!("Event queued: {} from {}", request.event_name, request.struct_name);
+                }
+            }
+        }
+    }
+}
+
+// Separate exclusive system to actually send the events
+pub fn send_queued_events_system(world: &mut World) {
+    let mut queue = EVENT_REQUEST_QUEUE.lock().unwrap();
+    
+    if !queue.is_empty() {
+        let registry = EVENT_REGISTRY.lock().unwrap();
+        
+        // Process each event request
+        for request in queue.drain(..) {
+            // Find the matching event info and sender
+            for event_info in registry.iter() {
+                if event_info.struct_name == request.struct_name {
+                    if let Some(index) = event_info.event_names.iter().position(|&name| name == request.event_name) {
+                        if let Some(sender) = event_info.event_senders.get(index) {
+                            sender(world);
+                            println!("Successfully sent event: {}", request.event_name);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/bevy_granite_editor/src/interface/tabs/events/ui.rs
+++ b/crates/bevy_granite_editor/src/interface/tabs/events/ui.rs
@@ -1,15 +1,13 @@
-use bevy_egui::egui;
 use bevy::prelude::*;
+use bevy_egui::egui;
 use std::sync::Mutex;
 
-// Registry for UI callable events - stores type information and event senders
 pub struct EventInfo {
     pub struct_name: &'static str,
     pub event_names: &'static [&'static str],
     pub event_senders: Vec<Box<dyn Fn(&mut World) + Send + Sync>>,
 }
 
-// Queue for pending event requests
 pub struct EventRequest {
     pub struct_name: String,
     pub event_name: String,
@@ -41,14 +39,7 @@ pub struct EventsTabData {
 }
 
 pub fn events_tab_ui(ui: &mut egui::Ui, data: &mut EventsTabData) {
-    let spacing = crate::UI_CONFIG.spacing;
-    
-    ui.label("UI Callable Events");
-    ui.add_space(spacing);
-    
-    ui.separator(); 
-    
-    // Dynamically create buttons from registry
+    let spacing = crate::UI_CONFIG.small_spacing;
     let registry = EVENT_REGISTRY.lock().unwrap();
     if registry.is_empty() {
         ui.label("No UI callable events registered yet.");
@@ -56,20 +47,59 @@ pub fn events_tab_ui(ui: &mut egui::Ui, data: &mut EventsTabData) {
         ui.label("Events will appear here when structs with #[ui_callable_events] are processed.");
     } else {
         for event_info in registry.iter() {
-            ui.label(format!("{}:", event_info.struct_name));
-            ui.add_space(spacing * 0.5);
-            
+            ui.label(format!("{}:", clean_name(event_info.struct_name)));
+            ui.add_space(spacing);
+            ui.separator();
+            ui.add_space(spacing);
+
             for event_name in event_info.event_names.iter() {
-                if ui.button(*event_name).clicked() {
-                    // Queue the event request
+                let clean_event_name = clean_name(event_name);
+                if ui.button(&clean_event_name).clicked() {
                     EVENT_REQUEST_QUEUE.lock().unwrap().push(EventRequest {
                         struct_name: event_info.struct_name.to_string(),
                         event_name: event_name.to_string(),
                     });
-                    data.button_clicked = Some(event_name.to_string());
+                    data.button_clicked = Some(clean_event_name);
                 }
+                ui.add_space(spacing);
             }
             ui.add_space(spacing);
         }
     }
+}
+
+fn clean_name(name: &str) -> String {
+    let mut result = String::new();
+    let mut chars = name.chars().peekable();
+    let mut is_first = true;
+
+    while let Some(ch) = chars.next() {
+        if ch == '_' {
+            if !is_first {
+                result.push(' ');
+            }
+        } else if ch.is_uppercase() && !is_first {
+            result.push(' ');
+            result.push(ch);
+        } else if is_first {
+            result.push(ch.to_uppercase().next().unwrap_or(ch));
+        } else {
+            result.push(ch);
+        }
+        is_first = false;
+    }
+
+    result
+        .split_whitespace()
+        .map(|word| {
+            let mut chars = word.chars();
+            match chars.next() {
+                None => String::new(),
+                Some(first) => {
+                    first.to_uppercase().collect::<String>() + &chars.as_str().to_lowercase()
+                }
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
 }

--- a/crates/bevy_granite_editor/src/interface/tabs/events/ui.rs
+++ b/crates/bevy_granite_editor/src/interface/tabs/events/ui.rs
@@ -1,0 +1,75 @@
+use bevy_egui::egui;
+use bevy::prelude::*;
+use std::sync::Mutex;
+
+// Registry for UI callable events - stores type information and event senders
+pub struct EventInfo {
+    pub struct_name: &'static str,
+    pub event_names: &'static [&'static str],
+    pub event_senders: Vec<Box<dyn Fn(&mut World) + Send + Sync>>,
+}
+
+// Queue for pending event requests
+pub struct EventRequest {
+    pub struct_name: String,
+    pub event_name: String,
+}
+
+lazy_static::lazy_static! {
+    pub static ref EVENT_REQUEST_QUEUE: Mutex<Vec<EventRequest>> = Mutex::new(Vec::new());
+}
+
+lazy_static::lazy_static! {
+    pub static ref EVENT_REGISTRY: Mutex<Vec<EventInfo>> = Mutex::new(Vec::new());
+}
+
+pub fn register_ui_callable_events_with_senders(
+    struct_name: &'static str,
+    event_names: &'static [&'static str],
+    event_senders: Vec<Box<dyn Fn(&mut World) + Send + Sync>>,
+) {
+    EVENT_REGISTRY.lock().unwrap().push(EventInfo {
+        struct_name,
+        event_names,
+        event_senders,
+    });
+}
+
+#[derive(PartialEq, Clone, Default)]
+pub struct EventsTabData {
+    pub button_clicked: Option<String>,
+}
+
+pub fn events_tab_ui(ui: &mut egui::Ui, data: &mut EventsTabData) {
+    let spacing = crate::UI_CONFIG.spacing;
+    
+    ui.label("UI Callable Events");
+    ui.add_space(spacing);
+    
+    ui.separator(); 
+    
+    // Dynamically create buttons from registry
+    let registry = EVENT_REGISTRY.lock().unwrap();
+    if registry.is_empty() {
+        ui.label("No UI callable events registered yet.");
+        ui.add_space(spacing);
+        ui.label("Events will appear here when structs with #[ui_callable_events] are processed.");
+    } else {
+        for event_info in registry.iter() {
+            ui.label(format!("{}:", event_info.struct_name));
+            ui.add_space(spacing * 0.5);
+            
+            for event_name in event_info.event_names.iter() {
+                if ui.button(*event_name).clicked() {
+                    // Queue the event request
+                    EVENT_REQUEST_QUEUE.lock().unwrap().push(EventRequest {
+                        struct_name: event_info.struct_name.to_string(),
+                        event_name: event_name.to_string(),
+                    });
+                    data.button_clicked = Some(event_name.to_string());
+                }
+            }
+            ui.add_space(spacing);
+        }
+    }
+}

--- a/crates/bevy_granite_editor/src/interface/tabs/events/ui.rs
+++ b/crates/bevy_granite_editor/src/interface/tabs/events/ui.rs
@@ -39,31 +39,30 @@ pub struct EventsTabData {
 }
 
 pub fn events_tab_ui(ui: &mut egui::Ui, data: &mut EventsTabData) {
-    let spacing = crate::UI_CONFIG.small_spacing;
+    let small_spacing = crate::UI_CONFIG.small_spacing;
+    let spacing = crate::UI_CONFIG.spacing;
     let registry = EVENT_REGISTRY.lock().unwrap();
     if registry.is_empty() {
-        ui.label("No UI callable events registered yet.");
-        ui.add_space(spacing);
         ui.label("Events will appear here when structs with #[ui_callable_events] are processed.");
     } else {
         for event_info in registry.iter() {
-            ui.label(format!("{}:", clean_name(event_info.struct_name)));
-            ui.add_space(spacing);
-            ui.separator();
-            ui.add_space(spacing);
-
-            for event_name in event_info.event_names.iter() {
-                let clean_event_name = clean_name(event_name);
-                if ui.button(&clean_event_name).clicked() {
-                    EVENT_REQUEST_QUEUE.lock().unwrap().push(EventRequest {
-                        struct_name: event_info.struct_name.to_string(),
-                        event_name: event_name.to_string(),
-                    });
-                    data.button_clicked = Some(clean_event_name);
-                }
+            ui.group(|ui| {
+                ui.label(format!("{}:", clean_name(event_info.struct_name)));
                 ui.add_space(spacing);
-            }
-            ui.add_space(spacing);
+                ui.set_width(ui.available_width());
+                for event_name in event_info.event_names.iter() {
+                    let clean_event_name = clean_name(event_name);
+                    if ui.button(&clean_event_name).clicked() {
+                        EVENT_REQUEST_QUEUE.lock().unwrap().push(EventRequest {
+                            struct_name: event_info.struct_name.to_string(),
+                            event_name: event_name.to_string(),
+                        });
+                        data.button_clicked = Some(clean_event_name);
+                    }
+                    ui.add_space(small_spacing);
+                }
+                ui.add_space(small_spacing);
+            });
         }
     }
 }

--- a/crates/bevy_granite_editor/src/interface/tabs/mod.rs
+++ b/crates/bevy_granite_editor/src/interface/tabs/mod.rs
@@ -12,6 +12,6 @@ pub use entity_editor::{
     update_entity_with_new_identity_system, update_entity_with_new_transform_system,
     update_material_handle_system, EntityEditorTabData,
 };
-pub use events::{events_tab_ui, send_queued_events_system, update_events_tab_system, EventsTabData};
+pub use events::{events_tab_ui, send_queued_events_system, EventsTabData};
 pub use log::{log_tab_ui, update_log_tab_system, LogTabData};
 pub use node_tree::{update_node_tree_tabs_system, NodeTreeTabData, RequestReparentEntityEvent};

--- a/crates/bevy_granite_editor/src/interface/tabs/mod.rs
+++ b/crates/bevy_granite_editor/src/interface/tabs/mod.rs
@@ -1,6 +1,7 @@
 pub mod debug;
 pub mod editor_settings;
 pub mod entity_editor;
+pub mod events;
 pub mod log;
 pub mod node_tree;
 
@@ -11,5 +12,6 @@ pub use entity_editor::{
     update_entity_with_new_identity_system, update_entity_with_new_transform_system,
     update_material_handle_system, EntityEditorTabData,
 };
+pub use events::{events_tab_ui, send_queued_events_system, update_events_tab_system, EventsTabData};
 pub use log::{log_tab_ui, update_log_tab_system, LogTabData};
 pub use node_tree::{update_node_tree_tabs_system, NodeTreeTabData, RequestReparentEntityEvent};

--- a/crates/bevy_granite_macros/Cargo.toml
+++ b/crates/bevy_granite_macros/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 syn = { version = "2.0", features = ["full"] }
 quote = "1.0"
 proc-macro2 = "1.0"
-inventory = "0.3.19"
 once_cell = "1.20.2"
 
 [lib]

--- a/crates/bevy_granite_macros/src/lib.rs
+++ b/crates/bevy_granite_macros/src/lib.rs
@@ -2,7 +2,7 @@ use once_cell::sync::Lazy;
 use proc_macro::TokenStream;
 use quote::quote;
 use std::sync::Mutex;
-use syn::{parse_macro_input, DeriveInput};
+use syn::{parse_macro_input, DeriveInput,};
 
 static REGISTERED_COMPONENTS: Lazy<Mutex<Vec<(String, bool)>>> =
     Lazy::new(|| Mutex::new(Vec::new()));
@@ -88,3 +88,71 @@ pub fn register_editor_components(input: TokenStream) -> TokenStream {
     };
     TokenStream::from(expanded)
 }
+
+#[proc_macro_attribute]
+pub fn ui_callable_events(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(item as DeriveInput);
+    let name = &input.ident;
+    let name_str = name.to_string();
+
+    // Extract field names and types from the struct
+    let (field_names, field_types): (Vec<_>, Vec<_>) = if let syn::Data::Struct(ref data_struct) = input.data {
+        if let syn::Fields::Named(ref fields_named) = data_struct.fields {
+            fields_named.named.iter().map(|field| {
+                let field_name = field.ident.as_ref().unwrap().to_string();
+                let field_type = &field.ty;
+                (field_name, field_type.clone())
+            }).unzip()
+        } else {
+            (Vec::new(), Vec::new())
+        }
+    } else {
+        (Vec::new(), Vec::new())
+    };
+
+    // Generate event sender closures
+    let event_senders = field_types.iter().map(|field_type| {
+        quote! {
+            Box::new(|world: &mut bevy::prelude::World| {
+                world.send_event(#field_type::default());
+            }) as Box<dyn Fn(&mut bevy::prelude::World) + Send + Sync>
+        }
+    });
+
+    let expanded = quote! {
+        #input
+        
+        impl bevy_granite_core::UICallableEventMarker for #name {}
+        
+        impl bevy_granite_core::UICallableEventProvider for #name {
+            fn get_event_names() -> &'static [&'static str] {
+                &[#(#field_names),*]
+            }
+            
+            fn get_struct_name() -> &'static str {
+                #name_str
+            }
+        }
+        
+        impl #name {
+            pub fn get_event_types() -> &'static [&'static str] {
+                &[#(stringify!(#field_types)),*]
+            }
+            
+            pub fn register_events() {
+                let event_senders = vec![#(#event_senders),*];
+                let event_names: &'static [&'static str] = &[#(#field_names),*];
+                
+                // Use the registration function - this will be provided by the user's import
+                bevy_granite::prelude::register_ui_callable_events_with_senders(
+                    #name_str,
+                    event_names,
+                    event_senders,
+                );
+            }
+        }
+    };
+    
+    TokenStream::from(expanded)
+}
+

--- a/crates/bevy_granite_macros/src/lib.rs
+++ b/crates/bevy_granite_macros/src/lib.rs
@@ -139,7 +139,7 @@ pub fn ui_callable_events(_attr: TokenStream, item: TokenStream) -> TokenStream 
                 &[#(stringify!(#field_types)),*]
             }
             
-            pub fn register_events() {
+            pub fn register_ui() {
                 let event_senders = vec![#(#event_senders),*];
                 let event_names: &'static [&'static str] = &[#(#field_names),*];
                 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,8 +145,10 @@ pub mod prelude {
             WorldLoadSuccessEvent, WorldSaveSuccessEvent,
         },
         bevy_granite_logging::{log, LogCategory, LogLevel, LogType},
-        bevy_granite_macros::{granite_component, register_editor_components},
+        bevy_granite_macros::{granite_component, register_editor_components, ui_callable_events},
     };
+
+
 
     #[cfg(feature = "gizmos")]
     pub use crate::bevy_granite_gizmos::{
@@ -158,4 +160,7 @@ pub mod prelude {
         RequestCameraEntityFrame, RequestEditorToggle, RequestNewParent, RequestRemoveChildren,
         RequestRemoveParents, RequestToggleCameraSync,
     };
+
+    #[cfg(feature = "editor")]
+    pub use crate::bevy_granite_editor::interface::tabs::events::ui::register_ui_callable_events_with_senders;
 }


### PR DESCRIPTION
(Super messy as macros are out of my wheelhouse and AI came to the rescue.)

Allows a struct with events to be tagged so that it can be exposed into the editor UI for quick dispatching. I imagine this can be used in a variety of debug ways
<img width="274" height="249" alt="image" src="https://github.com/user-attachments/assets/af2b4851-e371-47ac-918c-f740db54cdd2" />

Assuming your events are registered - take a new struct that contains said event and call the macro attribute ```[#ui_callable_events]```. Make sure to call the structs namespace with register_ui like this ```DebugEvents::register_ui();``` **BEFORE** your app render loop.

I created a test that simply despawns or spawns my player.
```rust
#[derive(Event, Default)]
pub struct DebugRequestPlayer;

#[derive(Event, Default)]
pub struct DebugRequestRemovePlayer;

#[ui_callable_events]
pub struct DebugEvents {
    pub spawn_player: DebugRequestPlayer,
    pub remove_player: DebugRequestRemovePlayer,
}

pub fn debug_callable_watcher(
    mut despawn: EventReader<DebugRequestRemovePlayer>,
    mut spawn: EventReader<DebugRequestPlayer>,
    mut commands: Commands,
    mut player_start: Query<(&GlobalTransform, &mut PlayerSpawner)>,
    mut world_state: ResMut<WorldState>,
) {
    for DebugRequestRemovePlayer in despawn.read() {
        commands.send_event(RequestDespawnBySource(PLAYER_PREFAB.to_string()));
    }

    for DebugRequestPlayer in spawn.read() {
        spawn_player(&mut commands, &mut world_state, &mut player_start);
    }
}

```

I wanted a way to expose events to buttons in the UI for debugging my game. This was my solution, but happy to hear opinions on it.