### PR TITLE
Port 0.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,20 +3,20 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.dependencies]
-bevy = { version = "0.16.1", default-features = false }
-bevy-inspector-egui = "0.33"
-bevy_obj = "0.16.1"
-bevy_egui = "0.36"
+bevy = { version = "0.17.2", default-features = false }
+bevy-inspector-egui = "0.34.0"
+bevy_obj = "0.17.0"
+bevy_egui = "0.37.0"
 toml = "0.8.22"
 uuid = "1.17.0"
-serde = "1.0.215"
+serde = "1.0"
 native-dialog = "0.7.0"
 ron = "0.8.1"
 lazy_static = "1.5.0"
 
 [package]
 name = "bevy_granite"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "A 3d editor for the Bevy game engine."
 

--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ pub struct DebugEvents {
 }
 
 pub fn debug_callable_watcher(
-    mut despawn: EventReader<DebugRequestRemovePlayer>,
-    mut spawn: EventReader<DebugRequestPlayer>,
+    mut despawn: MessageReader<DebugRequestRemovePlayer>,
+    mut spawn: MessageReader<DebugRequestPlayer>,
     mut commands: Commands,
     mut player_start: Query<(&GlobalTransform, &mut PlayerSpawner)>,
     mut world_state: ResMut<WorldState>,

--- a/crates/bevy_granite_core/Cargo.toml
+++ b/crates/bevy_granite_core/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 toml = { workspace = true }
-bevy = { workspace = true, features = ["bevy_pbr", "png"] }
+bevy = { workspace = true, features = ["bevy_pbr", "png", "reflect_auto_register"] }
 bevy-inspector-egui = { workspace = true }
 bevy_egui = { workspace = true }
 bevy_obj = { workspace = true }

--- a/crates/bevy_granite_core/src/entities/deserialize.rs
+++ b/crates/bevy_granite_core/src/entities/deserialize.rs
@@ -1,12 +1,14 @@
 use super::{ComponentEditor, EntitySaveReadyData, IdentityData, SceneData, SpawnSource};
 use crate::{
-    absolute_asset_to_rel, entities::SaveSettings, materials_from_folder_into_scene, rel_asset_to_absolute, shared::is_scene_version_compatible, AvailableEditableMaterials, GraniteType, TransformData
+    absolute_asset_to_rel, entities::SaveSettings, materials_from_folder_into_scene,
+    rel_asset_to_absolute, shared::is_scene_version_compatible, AvailableEditableMaterials,
+    GraniteType, TransformData,
 };
 use bevy::{
     ecs::{entity::Entity, system::ResMut, world::World},
+    mesh::Mesh,
     pbr::StandardMaterial,
     prelude::{AppTypeRegistry, AssetServer, Assets, Commands, Component, Reflect, Res},
-    render::mesh::Mesh,
     transform::components::Transform,
 };
 use bevy_granite_logging::{
@@ -73,7 +75,9 @@ pub fn deserialize_entities(
 
         // Tag entity with its source file
         let relative: Cow<'static, str> = absolute_asset_to_rel(abs_path.to_string());
-        commands.entity(entity).insert(SpawnSource::new(relative, save_settings.clone()));
+        commands
+            .entity(entity)
+            .insert(SpawnSource::new(relative, save_settings.clone()));
 
         // Store parent relationships for second pass
         if let Some(parent_guid) = save_data.parent {
@@ -348,7 +352,8 @@ fn spawn_entity_from_class_type(
     // Apply transform offset if provided and parent entity
     if let Some(offset) = transform_offset {
         if save_data.parent.is_none() {
-            modified_save_data.transform = offset_saved_transform(modified_save_data.transform, offset);
+            modified_save_data.transform =
+                offset_saved_transform(modified_save_data.transform, offset);
         }
     }
 

--- a/crates/bevy_granite_core/src/entities/editable/README.md
+++ b/crates/bevy_granite_core/src/entities/editable/README.md
@@ -38,14 +38,14 @@ In `types/your_type/update_event.rs`:
 ```rust
 use bevy::prelude::*;
 
-#[derive(Event)]
+#[derive(Message)]
 pub struct UpdateYourTypeEvent {
     pub entity: Entity,
     pub new_data: YourType,
 }
 
 pub fn update_your_type_system(
-    mut events: EventReader<UpdateYourTypeEvent>,
+    mut events: MessageReader<UpdateYourTypeEvent>,
     mut query: Query<&mut YourType>, // and any related bevy info you need
 ) {
     // Handle type update events
@@ -63,7 +63,7 @@ pub struct YourTypePlugin;
 
 impl Plugin for YourTypePlugin {
     fn build(&self, app: &mut App) {
-        app.add_event::<UpdateYourTypeEvent>()
+        app.add_message::<UpdateYourTypeEvent>()
            .register_type::<YourType>
            .add_systems(Update, update_your_type_system);
     }
@@ -106,8 +106,8 @@ impl GraniteTypes {
 In `editable/mod.rs`, add your update event to the `RequestEntityUpdateFromClass` SystemParam:
 
 ```rust
-// Add EventWriter for your type
-pub your_type_writer: EventWriter<'w, UpdateYourTypeEvent>,
+// Add MessageWriter for your type
+pub your_type_writer: MessageWriter<'w, UpdateYourTypeEvent>,
 ```
 
 ## Step 8: Export Your Type

--- a/crates/bevy_granite_core/src/entities/editable/mod.rs
+++ b/crates/bevy_granite_core/src/entities/editable/mod.rs
@@ -8,10 +8,10 @@ use bevy::{
         entity::Entity,
         system::{Commands, Res, ResMut},
     },
-    ecs::{event::EventWriter, system::SystemParam},
+    ecs::{message::MessageWriter, system::SystemParam},
+    mesh::Mesh,
     pbr::StandardMaterial,
     prelude::{Image, Reflect},
-    render::mesh::Mesh,
     transform::components::Transform,
 };
 use bevy_egui::egui;
@@ -33,12 +33,12 @@ pub use types::*;
 
 #[derive(SystemParam)]
 pub struct RequestEntityUpdateFromClass<'w> {
-    pub camera_3d: EventWriter<'w, UserUpdatedCamera3DEvent>,
-    pub directional_light: EventWriter<'w, UserUpdatedDirectionalLightEvent>,
-    pub point_light: EventWriter<'w, UserUpdatedPointLightEvent>,
-    pub rectangle_brush: EventWriter<'w, UserUpdatedRectBrushEvent>,
-    pub obj: EventWriter<'w, UserUpdatedOBJEvent>,
-    pub empty: EventWriter<'w, UserUpdatedEmptyEvent>,
+    pub camera_3d: MessageWriter<'w, UserUpdatedCamera3DEvent>,
+    pub directional_light: MessageWriter<'w, UserUpdatedDirectionalLightEvent>,
+    pub point_light: MessageWriter<'w, UserUpdatedPointLightEvent>,
+    pub rectangle_brush: MessageWriter<'w, UserUpdatedRectBrushEvent>,
+    pub obj: MessageWriter<'w, UserUpdatedOBJEvent>,
+    pub empty: MessageWriter<'w, UserUpdatedEmptyEvent>,
 }
 
 // ---------------------------------------------------------------------------------------

--- a/crates/bevy_granite_core/src/entities/editable/types/camera_3d/creation.rs
+++ b/crates/bevy_granite_core/src/entities/editable/types/camera_3d/creation.rs
@@ -4,10 +4,9 @@ use crate::{
     HasRuntimeData, IdentityData,
 };
 use bevy::{
-    core_pipeline::core_3d::Camera3d,
+    camera::{Camera, Camera3d},
     ecs::{bundle::Bundle, entity::Entity, system::Commands},
     prelude::Name,
-    render::camera::Camera,
     transform::components::Transform,
 };
 use uuid::Uuid;
@@ -56,8 +55,8 @@ impl Camera3D {
             commands.spawn(Self::get_bundle(self.clone(), identity.clone(), transform));
 
         if self.has_volumetric_fog {
-            let mut fog = bevy::pbr::VolumetricFog::default();
-            let mut fog_volume = bevy::pbr::FogVolume::default();
+            let mut fog = bevy::light::VolumetricFog::default();
+            let mut fog_volume = bevy::light::FogVolume::default();
 
             if let Some(fog_settings) = &self.volumetric_fog_settings {
                 fog.ambient_color = fog_settings.ambient_color;

--- a/crates/bevy_granite_core/src/entities/editable/types/camera_3d/mod.rs
+++ b/crates/bevy_granite_core/src/entities/editable/types/camera_3d/mod.rs
@@ -1,16 +1,16 @@
 use crate::entities::editable::{GraniteType, RequestEntityUpdateFromClass};
 use crate::{entities::EntitySaveReadyData, AvailableEditableMaterials};
+use bevy::ecs::message::Message;
 use bevy::{
     asset::{AssetServer, Assets},
     color::Color,
     ecs::{
         entity::Entity,
-        event::Event,
         system::{Commands, Res, ResMut},
     },
+    mesh::Mesh,
     pbr::StandardMaterial,
     prelude::Reflect,
-    render::mesh::Mesh,
     transform::components::Transform,
 };
 use bevy_egui::egui;
@@ -27,7 +27,7 @@ pub use plugin::*;
 pub use update_event::*;
 
 /// Internal event thats called when user edits UI camera variable
-#[derive(Event)]
+#[derive(Message)]
 pub struct UserUpdatedCamera3DEvent {
     pub entity: Entity,
     pub data: Camera3D,
@@ -92,19 +92,19 @@ impl GraniteType for Camera3D {
     fn type_name(&self) -> String {
         "Camera 3D".to_string()
     }
-    
+
     fn type_abv(&self) -> String {
         "3D Cam".to_string()
     }
-    
+
     fn category(&self) -> ClassCategory {
         ClassCategory::Gameplay
     }
-    
+
     fn get_embedded_icon_bytes(&self) -> Option<&'static [u8]> {
         Some(include_bytes!("Camera.png"))
     }
-    
+
     fn get_icon_filename(&self) -> Option<&'static str> {
         Some("Camera.png")
     }

--- a/crates/bevy_granite_core/src/entities/editable/types/camera_3d/plugin.rs
+++ b/crates/bevy_granite_core/src/entities/editable/types/camera_3d/plugin.rs
@@ -9,7 +9,7 @@ impl Plugin for Camera3DPlugin {
             //
             // Event
             //
-            .add_event::<UserUpdatedCamera3DEvent>()
+            .add_message::<UserUpdatedCamera3DEvent>()
             //
             // Register
             //

--- a/crates/bevy_granite_core/src/entities/editable/types/camera_3d/update_event.rs
+++ b/crates/bevy_granite_core/src/entities/editable/types/camera_3d/update_event.rs
@@ -3,13 +3,13 @@ use crate::{
     entities::editable::RequestEntityUpdateFromClass, Camera3D, GraniteTypes, IdentityData,
 };
 use bevy::{
+    camera::Camera,
     ecs::{
         entity::Entity,
-        event::EventReader,
+        message::MessageReader,
         system::{Commands, Query},
     },
-    pbr::{FogVolume, VolumetricFog as VolumetricFogSettings},
-    render::camera::Camera,
+    light::{FogVolume, VolumetricFog as VolumetricFogSettings},
 };
 
 use bevy_granite_logging::{log, LogCategory, LogLevel, LogType};
@@ -38,7 +38,7 @@ impl Camera3D {
 /// Actually update the specific entity with the class data
 /// In the future im sure we will have FOV and what not
 pub fn update_camera_3d_system(
-    mut reader: EventReader<UserUpdatedCamera3DEvent>,
+    mut reader: MessageReader<UserUpdatedCamera3DEvent>,
     mut query: Query<(Entity, &mut Camera, &mut IdentityData)>,
     mut commands: Commands,
 ) {

--- a/crates/bevy_granite_core/src/entities/editable/types/directional_light/creation.rs
+++ b/crates/bevy_granite_core/src/entities/editable/types/directional_light/creation.rs
@@ -6,7 +6,7 @@ use crate::{
 use bevy::{
     color::Color,
     ecs::{bundle::Bundle, entity::Entity, system::Commands},
-    pbr::{DirectionalLight, VolumetricLight},
+    light::{DirectionalLight, VolumetricLight},
     prelude::Name,
     transform::components::Transform,
 };

--- a/crates/bevy_granite_core/src/entities/editable/types/directional_light/mod.rs
+++ b/crates/bevy_granite_core/src/entities/editable/types/directional_light/mod.rs
@@ -2,12 +2,12 @@ use bevy::{
     asset::{AssetServer, Assets},
     ecs::{
         entity::Entity,
-        event::Event,
+        message::Message,
         system::{Commands, Res, ResMut},
     },
+    mesh::Mesh,
     pbr::StandardMaterial,
     prelude::Reflect,
-    render::mesh::Mesh,
     transform::components::Transform,
 };
 use bevy_egui::egui;
@@ -18,17 +18,17 @@ pub mod plugin;
 pub mod ui;
 pub mod update_event;
 
-use crate::{ClassCategory, PromptData};
 use crate::{
     entities::editable::{GraniteType, RequestEntityUpdateFromClass},
     entities::EntitySaveReadyData,
     AvailableEditableMaterials,
 };
+use crate::{ClassCategory, PromptData};
 pub use plugin::*;
 pub use update_event::*;
 
 /// Internal event thats called when user edits UI directional light variable
-#[derive(Event)]
+#[derive(Message)]
 pub struct UserUpdatedDirectionalLightEvent {
     pub entity: Entity,
     pub data: DirLight,
@@ -71,7 +71,7 @@ impl GraniteType for DirLight {
     fn get_embedded_icon_bytes(&self) -> Option<&'static [u8]> {
         Some(include_bytes!("DirectionalLight.png"))
     }
-    
+
     fn get_icon_filename(&self) -> Option<&'static str> {
         Some("DirectionalLight.png")
     }

--- a/crates/bevy_granite_core/src/entities/editable/types/directional_light/plugin.rs
+++ b/crates/bevy_granite_core/src/entities/editable/types/directional_light/plugin.rs
@@ -10,7 +10,7 @@ impl Plugin for DirLightPlugin {
             //
             // Event
             //
-            .add_event::<UserUpdatedDirectionalLightEvent>()
+            .add_message::<UserUpdatedDirectionalLightEvent>()
             //
             // Register
             //

--- a/crates/bevy_granite_core/src/entities/editable/types/directional_light/update_event.rs
+++ b/crates/bevy_granite_core/src/entities/editable/types/directional_light/update_event.rs
@@ -6,10 +6,10 @@ use bevy::{
     color::Color,
     ecs::{
         entity::Entity,
-        event::EventReader,
+        message::MessageReader,
         system::{Commands, Query},
     },
-    pbr::{DirectionalLight, VolumetricLight},
+    light::{DirectionalLight, VolumetricLight},
 };
 use bevy_granite_logging::{log, LogCategory, LogLevel, LogType};
 
@@ -39,7 +39,7 @@ impl DirLight {
 /// Actually update the specific entity with the class data
 /// In the future im sure we will have FOV and what not
 pub fn update_directional_light_system(
-    mut reader: EventReader<UserUpdatedDirectionalLightEvent>,
+    mut reader: MessageReader<UserUpdatedDirectionalLightEvent>,
     mut query: Query<(Entity, &mut DirectionalLight)>,
     mut commands: Commands,
 ) {

--- a/crates/bevy_granite_core/src/entities/editable/types/empty/creation.rs
+++ b/crates/bevy_granite_core/src/entities/editable/types/empty/creation.rs
@@ -4,9 +4,9 @@ use crate::{
     HasRuntimeData, IdentityData,
 };
 use bevy::{
+    camera::visibility::Visibility,
     ecs::{bundle::Bundle, entity::Entity, system::Commands},
     prelude::Name,
-    render::view::Visibility,
     transform::components::Transform,
 };
 use uuid::Uuid;

--- a/crates/bevy_granite_core/src/entities/editable/types/empty/mod.rs
+++ b/crates/bevy_granite_core/src/entities/editable/types/empty/mod.rs
@@ -1,17 +1,20 @@
 use crate::{
-    entities::{editable::{GraniteType, RequestEntityUpdateFromClass}, EntitySaveReadyData},
+    entities::{
+        editable::{GraniteType, RequestEntityUpdateFromClass},
+        EntitySaveReadyData,
+    },
     AvailableEditableMaterials, ClassCategory, PromptData,
 };
 use bevy::{
     asset::{AssetServer, Assets},
     ecs::{
         entity::Entity,
-        event::Event,
+        message::Message,
         system::{Commands, Res, ResMut},
     },
+    mesh::Mesh,
     pbr::StandardMaterial,
     reflect::Reflect,
-    render::mesh::Mesh,
     transform::components::Transform,
 };
 use bevy_egui::egui;
@@ -27,7 +30,7 @@ pub use update_event::*;
 
 // We have no event here as there isnt data that can be edited via UI
 /// Internal event thats called when user edits UI directional light variable
-#[derive(Event)]
+#[derive(Message)]
 pub struct UserUpdatedEmptyEvent {
     pub entity: Entity,
     pub data: Empty,

--- a/crates/bevy_granite_core/src/entities/editable/types/empty/plugin.rs
+++ b/crates/bevy_granite_core/src/entities/editable/types/empty/plugin.rs
@@ -8,7 +8,7 @@ impl Plugin for EmptyPlugin {
             //
             // Event
             //
-            .add_event::<UserUpdatedEmptyEvent>()
+            .add_message::<UserUpdatedEmptyEvent>()
             //
             // Register
             //

--- a/crates/bevy_granite_core/src/entities/editable/types/empty/update_event.rs
+++ b/crates/bevy_granite_core/src/entities/editable/types/empty/update_event.rs
@@ -1,7 +1,8 @@
 use crate::entities::editable::RequestEntityUpdateFromClass;
 use crate::entities::editable::UserUpdatedEmptyEvent;
 use crate::entities::Empty;
-use bevy::ecs::{entity::Entity, event::EventReader};
+use bevy::ecs::entity::Entity;
+use bevy::ecs::message::MessageReader;
 use bevy_granite_logging::{log, LogCategory, LogLevel, LogType};
 
 impl Empty {
@@ -26,7 +27,7 @@ impl Empty {
 
 /// Actually update the specific entity with the class data
 /// In the future im sure we will have FOV and what not
-pub fn update_empty_system(mut reader: EventReader<UserUpdatedEmptyEvent>) {
+pub fn update_empty_system(mut reader: MessageReader<UserUpdatedEmptyEvent>) {
     for UserUpdatedEmptyEvent {
         entity: requested_entity,
         data: _new,

--- a/crates/bevy_granite_core/src/entities/editable/types/obj/creation.rs
+++ b/crates/bevy_granite_core/src/entities/editable/types/obj/creation.rs
@@ -5,15 +5,15 @@ use crate::{
     IdentityData, MaterialNameSource, NeedsTangents, PromptData, PromptImportSettings,
 };
 use bevy::{
-    asset::{AssetServer, Assets, Handle},
+    asset::{AssetPath, AssetServer, Assets, Handle},
     ecs::{
         bundle::Bundle,
         entity::Entity,
         system::{Commands, Res, ResMut},
     },
+    mesh::{Mesh, Mesh3d},
     pbr::{MeshMaterial3d, StandardMaterial},
     prelude::Name,
-    render::mesh::{Mesh, Mesh3d},
     transform::components::Transform,
 };
 use bevy_granite_logging::{
@@ -157,7 +157,9 @@ impl OBJ {
             create_material_from,
         );
 
-        let mesh_handle: Handle<Mesh> = asset_server.load(self.mesh_path.as_ref());
+        let path = self.mesh_path.to_string();
+
+        let mesh_handle: Handle<Mesh> = asset_server.load(path);
 
         commands
             .spawn(Self::get_bundle(

--- a/crates/bevy_granite_core/src/entities/editable/types/obj/mod.rs
+++ b/crates/bevy_granite_core/src/entities/editable/types/obj/mod.rs
@@ -11,12 +11,12 @@ use bevy::{
     asset::{AssetServer, Assets},
     ecs::{
         entity::Entity,
-        event::Event,
+        message::Message,
         system::{Commands, Res, ResMut},
     },
+    mesh::Mesh,
     pbr::StandardMaterial,
     prelude::Reflect,
-    render::mesh::Mesh,
     transform::components::Transform,
 };
 use bevy_egui::egui;
@@ -31,7 +31,7 @@ pub use plugin::*;
 pub use update_event::*;
 
 /// Internal event thats called when user edits UI OBJ variables
-#[derive(Event)]
+#[derive(Message)]
 pub struct UserUpdatedOBJEvent {
     pub entity: Entity,
     pub data: OBJ,

--- a/crates/bevy_granite_core/src/entities/editable/types/obj/plugin.rs
+++ b/crates/bevy_granite_core/src/entities/editable/types/obj/plugin.rs
@@ -9,7 +9,7 @@ impl Plugin for OBJPlugin {
             //
             // Event
             //
-            .add_event::<UserUpdatedOBJEvent>()
+            .add_message::<UserUpdatedOBJEvent>()
             //
             // Register
             //

--- a/crates/bevy_granite_core/src/entities/editable/types/obj/update_event.rs
+++ b/crates/bevy_granite_core/src/entities/editable/types/obj/update_event.rs
@@ -2,9 +2,13 @@ use super::UserUpdatedOBJEvent;
 use crate::{entities::editable::RequestEntityUpdateFromClass, NeedsTangents, OBJ};
 use bevy::{
     asset::AssetServer,
-    ecs::{entity::Entity, event::EventReader, system::{Commands, Res}},
+    ecs::{
+        entity::Entity,
+        message::MessageReader,
+        system::{Commands, Res},
+    },
+    mesh::Mesh3d,
     prelude::Query,
-    render::mesh::Mesh3d,
 };
 use bevy_granite_logging::{log, LogCategory, LogLevel, LogType};
 
@@ -30,7 +34,7 @@ impl OBJ {
 }
 
 pub fn update_obj_system(
-    mut reader: EventReader<UserUpdatedOBJEvent>,
+    mut reader: MessageReader<UserUpdatedOBJEvent>,
     mesh_query: Query<&Mesh3d>,
     mut commands: Commands,
     asset_server: Res<AssetServer>,
@@ -52,9 +56,10 @@ pub fn update_obj_system(
         if *reload_mesh {
             if let Ok(_mesh3d) = mesh_query.get(*requested_entity) {
                 // Force reload the asset by path
-                asset_server.reload(new_obj_data.mesh_path.as_ref());
+                let path = new_obj_data.mesh_path.to_string();
+                asset_server.reload(path);
                 commands.entity(*requested_entity).insert(NeedsTangents);
-                
+
                 log!(
                     LogType::Editor,
                     LogLevel::Info,

--- a/crates/bevy_granite_core/src/entities/editable/types/point_light/creation.rs
+++ b/crates/bevy_granite_core/src/entities/editable/types/point_light/creation.rs
@@ -6,7 +6,7 @@ use crate::{
 use bevy::{
     color::Color,
     ecs::{bundle::Bundle, entity::Entity, system::Commands},
-    pbr::PointLight,
+    light::PointLight,
     prelude::Name,
     transform::components::Transform,
 };

--- a/crates/bevy_granite_core/src/entities/editable/types/point_light/mod.rs
+++ b/crates/bevy_granite_core/src/entities/editable/types/point_light/mod.rs
@@ -1,19 +1,19 @@
-use crate::{ClassCategory, PromptData};
 use crate::{
     entities::editable::{GraniteType, RequestEntityUpdateFromClass},
     entities::EntitySaveReadyData,
     AvailableEditableMaterials,
 };
+use crate::{ClassCategory, PromptData};
 use bevy::{
     asset::{AssetServer, Assets},
     ecs::{
         entity::Entity,
-        event::Event,
+        message::Message,
         system::{Commands, Res, ResMut},
     },
+    mesh::Mesh,
     pbr::StandardMaterial,
     prelude::Reflect,
-    render::mesh::Mesh,
     transform::components::Transform,
 };
 use bevy_egui::egui;
@@ -28,7 +28,7 @@ pub use plugin::*;
 pub use update_event::*;
 
 /// Internal event thats called when user edits UI point light variable
-#[derive(Event)]
+#[derive(Message)]
 pub struct UserUpdatedPointLightEvent {
     pub entity: Entity,
     pub data: PointLightData,
@@ -62,7 +62,7 @@ impl GraniteType for PointLightData {
     fn type_abv(&self) -> String {
         "P.Light".to_string()
     }
-    
+
     fn category(&self) -> ClassCategory {
         ClassCategory::Light
     }
@@ -70,7 +70,7 @@ impl GraniteType for PointLightData {
     fn get_embedded_icon_bytes(&self) -> Option<&'static [u8]> {
         Some(include_bytes!("PointLight.png"))
     }
-    
+
     fn get_icon_filename(&self) -> Option<&'static str> {
         Some("PointLight.png")
     }

--- a/crates/bevy_granite_core/src/entities/editable/types/point_light/plugin.rs
+++ b/crates/bevy_granite_core/src/entities/editable/types/point_light/plugin.rs
@@ -9,7 +9,7 @@ impl Plugin for PointLightPlugin {
             //
             // Event
             //
-            .add_event::<UserUpdatedPointLightEvent>()
+            .add_message::<UserUpdatedPointLightEvent>()
             //
             // Register
             //

--- a/crates/bevy_granite_core/src/entities/editable/types/point_light/update_event.rs
+++ b/crates/bevy_granite_core/src/entities/editable/types/point_light/update_event.rs
@@ -4,8 +4,8 @@ use crate::{
 };
 use bevy::{
     color::Color,
-    ecs::{entity::Entity, event::EventReader, system::Query},
-    pbr::PointLight,
+    ecs::{entity::Entity, message::MessageReader, system::Query},
+    light::PointLight,
 };
 use bevy_granite_logging::{log, LogCategory, LogLevel, LogType};
 
@@ -33,7 +33,7 @@ impl PointLightData {
 }
 
 pub fn update_point_light_system(
-    mut reader: EventReader<UserUpdatedPointLightEvent>,
+    mut reader: MessageReader<UserUpdatedPointLightEvent>,
     mut query: Query<(Entity, &mut PointLight)>,
 ) {
     for UserUpdatedPointLightEvent {

--- a/crates/bevy_granite_core/src/entities/editable/types/rect_brush/creation.rs
+++ b/crates/bevy_granite_core/src/entities/editable/types/rect_brush/creation.rs
@@ -4,19 +4,16 @@ use crate::{
     GraniteType, GraniteTypes, HasRuntimeData, IdentityData, NeedsTangents,
 };
 use bevy::{
-    asset::{AssetServer, Assets},
+    asset::{AssetServer, Assets, RenderAssetUsages},
     ecs::{
         bundle::Bundle,
         entity::Entity,
         system::{Commands, Res, ResMut},
     },
     math::{Vec2, Vec3},
+    mesh::{Indices, Mesh, Mesh3d, PrimitiveTopology},
     pbr::{MeshMaterial3d, StandardMaterial},
     prelude::Name,
-    render::{
-        mesh::{Indices, Mesh, Mesh3d, PrimitiveTopology},
-        render_asset::RenderAssetUsages,
-    },
     transform::components::Transform,
 };
 use uuid::Uuid;

--- a/crates/bevy_granite_core/src/entities/editable/types/rect_brush/mod.rs
+++ b/crates/bevy_granite_core/src/entities/editable/types/rect_brush/mod.rs
@@ -1,21 +1,25 @@
 use crate::{
     assets::EditableMaterial,
-    entities::{editable::{
-        GraniteType, RequestEntityUpdateFromClass, RequiredMaterialData, RequiredMaterialDataMut,
-    }, EntitySaveReadyData, PromptData},
+    entities::{
+        editable::{
+            GraniteType, RequestEntityUpdateFromClass, RequiredMaterialData,
+            RequiredMaterialDataMut,
+        },
+        EntitySaveReadyData, PromptData,
+    },
     AvailableEditableMaterials, ClassCategory, MaterialData,
 };
 use bevy::{
     asset::{AssetServer, Assets},
     ecs::{
         entity::Entity,
-        event::Event,
+        message::Message,
         system::{Commands, Res, ResMut},
     },
     math::{Vec2, Vec3},
+    mesh::Mesh,
     pbr::StandardMaterial,
     prelude::Reflect,
-    render::mesh::Mesh,
     transform::components::Transform,
 };
 use bevy_egui::egui;
@@ -30,7 +34,7 @@ pub use plugin::*;
 pub use update_event::*;
 
 /// Internal event thats called when user edits UI RectBrush variables
-#[derive(Event)]
+#[derive(Message)]
 pub struct UserUpdatedRectBrushEvent {
     pub entity: Entity,
     pub data: RectBrush,
@@ -64,7 +68,10 @@ impl RectBrush {
 
 impl Default for RectBrush {
     fn default() -> Self {
-        let (path, name) = (Self::internal_material_path(), "Rectangle Brush".to_string());
+        let (path, name) = (
+            Self::internal_material_path(),
+            "Rectangle Brush".to_string(),
+        );
 
         // Create a material with the internal defaults for rectangle brush
         let mut brush_material = EditableMaterial::get_new_unnamed_base_color();

--- a/crates/bevy_granite_core/src/entities/editable/types/rect_brush/plugin.rs
+++ b/crates/bevy_granite_core/src/entities/editable/types/rect_brush/plugin.rs
@@ -10,7 +10,7 @@ impl Plugin for RectBrushPlugin {
             //
             // Event
             //
-            .add_event::<UserUpdatedRectBrushEvent>()
+            .add_message::<UserUpdatedRectBrushEvent>()
             //
             // Register
             //

--- a/crates/bevy_granite_core/src/entities/editable/types/rect_brush/update_event.rs
+++ b/crates/bevy_granite_core/src/entities/editable/types/rect_brush/update_event.rs
@@ -3,16 +3,14 @@ use crate::entities::editable::RequestEntityUpdateFromClass;
 use super::{RectBrush, UserUpdatedRectBrushEvent};
 use bevy::{
     asset::Assets,
+    camera::primitives::{Aabb, MeshAabb},
     ecs::{
-        event::EventReader,
+        message::MessageReader,
         system::{Query, ResMut},
     },
-    render::mesh::{Mesh3d, MeshAabb},
+    mesh::Mesh3d,
 };
-use bevy::{
-    prelude::Entity,
-    render::{mesh::Mesh, primitives::Aabb},
-};
+use bevy::{mesh::Mesh, prelude::Entity};
 use bevy_granite_logging::{log, LogCategory, LogLevel, LogType};
 
 impl RectBrush {
@@ -37,7 +35,7 @@ impl RectBrush {
 }
 
 pub fn update_rectangle_brush_system(
-    mut reader: EventReader<UserUpdatedRectBrushEvent>,
+    mut reader: MessageReader<UserUpdatedRectBrushEvent>,
     mut query: Query<(Entity, &Mesh3d)>,
     mut meshes: ResMut<Assets<Mesh>>,
     mut aabbs: Query<&mut Aabb>,

--- a/crates/bevy_granite_core/src/entities/editable/types/unknown.rs
+++ b/crates/bevy_granite_core/src/entities/editable/types/unknown.rs
@@ -8,9 +8,9 @@ use bevy::{
         entity::Entity,
         system::{Commands, Res, ResMut},
     },
+    mesh::Mesh,
     pbr::StandardMaterial,
     prelude::Reflect,
-    render::mesh::Mesh,
     transform::components::Transform,
 };
 use bevy_egui::egui;

--- a/crates/bevy_granite_core/src/entities/generate_tangents.rs
+++ b/crates/bevy_granite_core/src/entities/generate_tangents.rs
@@ -1,5 +1,7 @@
-use bevy::prelude::{AssetServer, Assets, Commands, Component, Entity, Query, Res, ResMut, With};
-use bevy::render::mesh::*;
+use bevy::{
+    mesh::{Mesh, Mesh3d},
+    prelude::{AssetServer, Assets, Commands, Component, Entity, Query, Res, ResMut, With},
+};
 use bevy_granite_logging::{
     config::{LogCategory, LogLevel, LogType},
     log,

--- a/crates/bevy_granite_core/src/entities/lifecycle.rs
+++ b/crates/bevy_granite_core/src/entities/lifecycle.rs
@@ -5,11 +5,11 @@ use bevy_granite_logging::{
     log,
 };
 
-use bevy::prelude::{Commands, Entity, EventReader, Query, With};
+use bevy::prelude::{Commands, Entity, MessageReader, Query, With};
 
 /// If entity has IdentityData, it is despawned
 pub fn despawn_entities_system(
-    mut despawn_watcher: EventReader<RequestDespawnSerializableEntities>,
+    mut despawn_watcher: MessageReader<RequestDespawnSerializableEntities>,
     mut commands: Commands,
     serializable_query: Query<Entity, With<IdentityData>>,
 ) {
@@ -27,7 +27,7 @@ pub fn despawn_entities_system(
 
 /// Despawn entities that have a specific SpawnSource
 pub fn despawn_entities_by_source_system(
-    mut despawn_watcher: EventReader<RequestDespawnBySource>,
+    mut despawn_watcher: MessageReader<RequestDespawnBySource>,
     mut commands: Commands,
     serializable_query: Query<(Entity, &SpawnSource), With<IdentityData>>,
 ) {

--- a/crates/bevy_granite_core/src/events.rs
+++ b/crates/bevy_granite_core/src/events.rs
@@ -1,34 +1,32 @@
-use bevy::{prelude::Event, transform::components::Transform};
 use crate::entities::SaveSettings;
+use bevy::{ecs::message::Message, prelude::Event, transform::components::Transform};
 
-#[derive(Event)]
+#[derive(Message)]
 pub struct RuntimeDataReadyEvent(pub String);
 
-#[derive(Event)]
+#[derive(Message)]
 pub struct CollectRuntimeDataEvent(pub String);
 
-#[derive(Event)]
+#[derive(Message)]
 pub struct WorldLoadSuccessEvent(pub String);
 
-#[derive(Event)]
+#[derive(Message)]
 pub struct WorldSaveSuccessEvent(pub String);
 
 // User callable events begin with "Request"
 
-#[derive(Event)]
+#[derive(Message)]
 pub struct RequestSaveEvent(pub String);
 
-#[derive(Event)]
+#[derive(Message)]
 pub struct RequestReloadEvent(pub String);
 
 /// Request the loading of serialized save data from a file. Optionally takes a Transform override to act as new loaded origin
-#[derive(Event)]
+#[derive(Message)]
 pub struct RequestLoadEvent(pub String, pub SaveSettings, pub Option<Transform>);
 
-#[derive(Event)]
+#[derive(Message)]
 pub struct RequestDespawnSerializableEntities;
 
-#[derive(Event)]
+#[derive(Message)]
 pub struct RequestDespawnBySource(pub String);
-
-

--- a/crates/bevy_granite_core/src/lib.rs
+++ b/crates/bevy_granite_core/src/lib.rs
@@ -45,7 +45,7 @@ pub use entities::{
     GraniteEditorSerdeEntity, GraniteType, GraniteTypes, HasRuntimeData, IdentityData, MainCamera,
     MaterialNameSource, NeedsTangents, PointLightData, PromptData, PromptImportSettings, RectBrush,
     ReflectedComponent, SaveSettings, SpawnSource, TransformData, TreeHiddenEntity, UICamera,
-    VolumetricFog, OBJ
+    VolumetricFog, OBJ,
 };
 pub use events::{
     CollectRuntimeDataEvent, RequestDespawnBySource, RequestDespawnSerializableEntities,
@@ -85,15 +85,15 @@ impl Plugin for BevyGraniteCore {
             //
             // Events
             //
-            .add_event::<RequestLoadEvent>()
-            .add_event::<WorldLoadSuccessEvent>()
-            .add_event::<RequestDespawnSerializableEntities>()
-            .add_event::<RequestDespawnBySource>()
-            .add_event::<WorldSaveSuccessEvent>()
-            .add_event::<RequestSaveEvent>()
-            .add_event::<CollectRuntimeDataEvent>()
-            .add_event::<RuntimeDataReadyEvent>()
-            .add_event::<RequestReloadEvent>()
+            .add_message::<RequestLoadEvent>()
+            .add_message::<WorldLoadSuccessEvent>()
+            .add_message::<RequestDespawnSerializableEntities>()
+            .add_message::<RequestDespawnBySource>()
+            .add_message::<WorldSaveSuccessEvent>()
+            .add_message::<RequestSaveEvent>()
+            .add_message::<CollectRuntimeDataEvent>()
+            .add_message::<RuntimeDataReadyEvent>()
+            .add_message::<RequestReloadEvent>()
             //
             // Resources
             //

--- a/crates/bevy_granite_core/src/world/open.rs
+++ b/crates/bevy_granite_core/src/world/open.rs
@@ -14,8 +14,8 @@ pub fn open_world_reader(
     mut materials: ResMut<Assets<StandardMaterial>>,
     meshes: ResMut<Assets<Mesh>>,
     mut available_materials: ResMut<AvailableEditableMaterials>,
-    mut world_open_reader: EventReader<RequestLoadEvent>,
-    mut world_load_success_writer: EventWriter<WorldLoadSuccessEvent>,
+    mut world_open_reader: MessageReader<RequestLoadEvent>,
+    mut world_load_success_writer: MessageWriter<WorldLoadSuccessEvent>,
 ) {
     if let Some(RequestLoadEvent(path, save_settings, translation)) =
         world_open_reader.read().next()

--- a/crates/bevy_granite_core/src/world/reload.rs
+++ b/crates/bevy_granite_core/src/world/reload.rs
@@ -3,14 +3,14 @@ use crate::{
     entities::{despawn_recursive_serializable_entities, IdentityData, SaveSettings},
     events::{RequestLoadEvent, RequestReloadEvent},
 };
-use bevy::prelude::{Commands, Entity, EventReader, EventWriter, Query, With};
+use bevy::prelude::{Commands, Entity, MessageReader, MessageWriter, Query, With};
 
 /// Despawns all entities then loads the world
 pub fn reload_world_system(
-    mut relead_watcher: EventReader<RequestReloadEvent>,
+    mut relead_watcher: MessageReader<RequestReloadEvent>,
     mut commands: Commands,
     serializable_query: Query<Entity, With<IdentityData>>,
-    mut load_world_writter: EventWriter<RequestLoadEvent>,
+    mut load_world_writter: MessageWriter<RequestLoadEvent>,
 ) {
     for RequestReloadEvent(path) in relead_watcher.read() {
         despawn_recursive_serializable_entities(&mut commands, &serializable_query);

--- a/crates/bevy_granite_core/src/world/save.rs
+++ b/crates/bevy_granite_core/src/world/save.rs
@@ -7,7 +7,7 @@ use crate::{
 use bevy::{
     asset::io::file::FileAssetReader,
     ecs::entity::Entity,
-    prelude::{ChildOf, Commands, EventReader, EventWriter, Query, ResMut, Resource, World},
+    prelude::{ChildOf, Commands, MessageReader, MessageWriter, Query, ResMut, Resource, World},
     transform::components::Transform,
 };
 use bevy_granite_logging::{
@@ -43,8 +43,8 @@ pub struct SaveWorldRequestData {
 /// Is runtime collector for registered type components
 pub fn save_request_system(
     mut save_request: ResMut<SaveWorldRequestData>,
-    mut event_writer: EventWriter<CollectRuntimeDataEvent>,
-    mut event_reader: EventReader<RequestSaveEvent>,
+    mut event_writer: MessageWriter<CollectRuntimeDataEvent>,
+    mut event_reader: MessageReader<RequestSaveEvent>,
     query: Query<(
         Entity,
         &IdentityData,
@@ -135,7 +135,7 @@ pub fn save_request_system(
 pub fn collect_components_system(
     mut commands: Commands,
     runtime_query: Query<(Entity, &HasRuntimeData, &SpawnSource)>,
-    mut event_reader: EventReader<CollectRuntimeDataEvent>,
+    mut event_reader: MessageReader<CollectRuntimeDataEvent>,
 ) {
     for CollectRuntimeDataEvent(spawn_source) in event_reader.read() {
         log!(
@@ -209,9 +209,9 @@ pub fn collect_components_system(
 
 /// Component data is ready, we can save the world
 pub fn save_data_ready_system(
-    mut event_reader: EventReader<RuntimeDataReadyEvent>,
+    mut event_reader: MessageReader<RuntimeDataReadyEvent>,
     mut save_request_data: ResMut<SaveWorldRequestData>,
-    mut saved_event_writer: EventWriter<WorldSaveSuccessEvent>,
+    mut saved_event_writer: MessageWriter<WorldSaveSuccessEvent>,
 ) {
     for RuntimeDataReadyEvent(source) in event_reader.read() {
         log!(

--- a/crates/bevy_granite_editor/src/editor_state/dock.rs
+++ b/crates/bevy_granite_editor/src/editor_state/dock.rs
@@ -3,7 +3,7 @@ use crate::{
         BottomDockState, EditorSettingsTabData, SideDockState, SideTab
     }
 };
-use bevy::{asset::io::file::FileAssetReader, prelude::{EventReader, Res}};
+use bevy::{asset::io::file::FileAssetReader, prelude::{MessageReader, Res}};
 use bevy::window::WindowClosing;
 use crate::utils::{load_from_toml_file, save_to_toml_file};
 use bevy_granite_logging::{
@@ -26,7 +26,7 @@ pub struct DockLayoutStr {
 }
 
 pub fn save_dock_on_window_close_system(
-    mut window_close_events: EventReader<WindowClosing>,
+    mut window_close_events: MessageReader<WindowClosing>,
     editor_state: Res<EditorState>,
     side_dock_res: Res<SideDockState>,
     bottom_dock_res: Res<BottomDockState>,

--- a/crates/bevy_granite_editor/src/editor_state/editor.rs
+++ b/crates/bevy_granite_editor/src/editor_state/editor.rs
@@ -4,13 +4,13 @@ use crate::{
 };
 
 use crate::utils::{load_from_toml_file, save_to_toml_file};
-use bevy::ecs::event::EventReader;
+use bevy::ecs::message::MessageReader;
 use bevy::{asset::io::file::FileAssetReader, prelude::ResMut};
 use bevy_granite_core::{
     absolute_asset_to_rel,
     events::{
-        RequestDespawnBySource, RequestDespawnSerializableEntities, 
-        WorldLoadSuccessEvent, WorldSaveSuccessEvent,
+        RequestDespawnBySource, RequestDespawnSerializableEntities, WorldLoadSuccessEvent,
+        WorldSaveSuccessEvent,
     },
 };
 use bevy_granite_logging::{
@@ -20,18 +20,18 @@ use bevy_granite_logging::{
 
 use crate::interface::RequestEditorToggle;
 use bevy::prelude::Commands;
-use bevy_granite_gizmos::{selection::events::EntityEvent, GizmoVisibilityState};
+use bevy_granite_gizmos::{selection::events::EntityEvents, GizmoVisibilityState};
 
 // editor.rs
 // This has functions related to saving the editor settings
 // Currently the settings data is coming directly from the right Tab settings.
 
 pub fn update_active_world_system(
-    mut open_success_reader: EventReader<WorldLoadSuccessEvent>,
-    mut world_save_success_reader: EventReader<WorldSaveSuccessEvent>,
-    mut entities_despawned_reader: EventReader<RequestDespawnSerializableEntities>,
-    mut entities_despawned_by_source_reader: EventReader<RequestDespawnBySource>,
-    mut set_active_world_reader: EventReader<SetActiveWorld>,
+    mut open_success_reader: MessageReader<WorldLoadSuccessEvent>,
+    mut world_save_success_reader: MessageReader<WorldSaveSuccessEvent>,
+    mut entities_despawned_reader: MessageReader<RequestDespawnSerializableEntities>,
+    mut entities_despawned_by_source_reader: MessageReader<RequestDespawnBySource>,
+    mut set_active_world_reader: MessageReader<SetActiveWorld>,
     mut editor_state: ResMut<EditorState>,
 ) {
     for RequestDespawnSerializableEntities in entities_despawned_reader.read() {
@@ -105,14 +105,14 @@ pub fn update_active_world_system(
 }
 
 pub fn update_editor_vis_system(
-    mut toggle_reader: EventReader<RequestEditorToggle>,
+    mut toggle_reader: MessageReader<RequestEditorToggle>,
     mut editor_state: ResMut<EditorState>,
     mut gizmo_state: ResMut<GizmoVisibilityState>,
     mut commands: Commands,
 ) {
     for RequestEditorToggle in toggle_reader.read() {
         // have to do it manually as watchers wont run when not active
-        commands.trigger(EntityEvent::DeselectAll);
+        commands.trigger(EntityEvents::DeselectAll);
 
         editor_state.active = !editor_state.active;
         gizmo_state.active = editor_state.active;

--- a/crates/bevy_granite_editor/src/entities/bounds.rs
+++ b/crates/bevy_granite_editor/src/entities/bounds.rs
@@ -1,5 +1,5 @@
+use bevy::mesh::{Mesh3d, VertexAttributeValues};
 use bevy::prelude::{Assets, Entity, Mesh, Query, Vec3};
-use bevy::render::mesh::{Mesh3d, VertexAttributeValues};
 use bevy::transform::components::GlobalTransform;
 use bevy_granite_core::{ClassCategory, GraniteType, IdentityData};
 

--- a/crates/bevy_granite_editor/src/entities/relationship.rs
+++ b/crates/bevy_granite_editor/src/entities/relationship.rs
@@ -8,7 +8,7 @@ use crate::interface::{
 use bevy::{
     ecs::{
         entity::Entity,
-        event::EventReader,
+        message::MessageReader,
         query::{With, Without},
         system::{Commands, Query},
     },
@@ -16,11 +16,11 @@ use bevy::{
     transform::commands::BuildChildrenTransformExt,
 };
 use bevy_granite_core::IconProxy;
-use bevy_granite_gizmos::{selection::events::EntityEvent, ActiveSelection, Selected};
+use bevy_granite_gizmos::{selection::events::EntityEvents, ActiveSelection, Selected};
 use bevy_granite_logging::*;
 
 pub fn parent_from_node_tree_system(
-    mut parent_request: EventReader<RequestReparentEntityEvent>,
+    mut parent_request: MessageReader<RequestReparentEntityEvent>,
     mut commands: Commands,
 ) {
     for request in parent_request.read() {
@@ -59,7 +59,7 @@ pub fn parent_from_node_tree_system(
 }
 
 pub fn parent_system(
-    mut parent_request: EventReader<RequestNewParent>,
+    mut parent_request: MessageReader<RequestNewParent>,
     active_selection: Query<Entity, With<ActiveSelection>>,
     selection: Query<Entity, (With<Selected>, Without<ActiveSelection>)>,
     mut commands: Commands,
@@ -89,7 +89,7 @@ pub fn parent_system(
 }
 
 pub fn parent_removal_system(
-    mut parent_request: EventReader<RequestRemoveParents>,
+    mut parent_request: MessageReader<RequestRemoveParents>,
     active_selection: Query<Entity, (With<ActiveSelection>, With<ChildOf>)>,
     selection: Query<Entity, (With<Selected>, With<ChildOf>)>,
     mut commands: Commands,
@@ -113,7 +113,7 @@ pub fn parent_removal_system(
 }
 
 pub fn parent_removal_from_entities_system(
-    mut parent_request: EventReader<RequestRemoveParentsFromEntities>,
+    mut parent_request: MessageReader<RequestRemoveParentsFromEntities>,
     mut commands: Commands,
 ) {
     for request in parent_request.read() {
@@ -140,7 +140,7 @@ pub fn parent_removal_from_entities_system(
 }
 
 pub fn child_removal_system(
-    mut child_request: EventReader<RequestRemoveChildren>,
+    mut child_request: MessageReader<RequestRemoveChildren>,
     selection: Query<Entity, (With<Selected>, With<Children>)>,
     active_selection: Query<Entity, (With<ActiveSelection>, With<ChildOf>)>,
     children_query: Query<&Children>,
@@ -170,7 +170,7 @@ pub fn child_removal_system(
 
         // Gizmo has weird issue where it stays in place when children are removed
         // so we deselect all entities to ensure it updates correctly
-        commands.trigger(EntityEvent::DeselectAll);
+        commands.trigger(EntityEvents::DeselectAll);
 
         log!(
             LogType::Editor,

--- a/crates/bevy_granite_editor/src/input/shortcuts.rs
+++ b/crates/bevy_granite_editor/src/input/shortcuts.rs
@@ -5,7 +5,7 @@ use bevy::{
 use bevy_granite_core::{
     entities::SaveSettings, RequestLoadEvent, RequestReloadEvent, RequestSaveEvent, UserInput,
 };
-use bevy_granite_gizmos::{selection::events::EntityEvent, Selected};
+use bevy_granite_gizmos::{selection::events::EntityEvents, Selected};
 use bevy_granite_logging::{log, LogCategory, LogLevel, LogType};
 use native_dialog::FileDialog;
 
@@ -106,7 +106,7 @@ fn handle_shortcuts(
             LogCategory::Input,
             "(shortcut) Deselecting all entities"
         );
-        commands.trigger(EntityEvent::DeselectAll);
+        commands.trigger(EntityEvents::DeselectAll);
     }
 
     // Shft-A

--- a/crates/bevy_granite_editor/src/interface/cache/sync.rs
+++ b/crates/bevy_granite_editor/src/interface/cache/sync.rs
@@ -1,4 +1,4 @@
-use bevy::ecs::{event::EventWriter, system::ResMut};
+use bevy::ecs::{message::MessageWriter, system::ResMut};
 use bevy_granite_logging::{
     config::{LogCategory, LogLevel, LogType},
     log,
@@ -21,7 +21,7 @@ use crate::interface::{
 pub fn update_components_from_cache(
     components_data: &mut EntityRegisteredData,
     cache: &mut ResMut<EntityUIDataCache>,
-    components_updated_writer: &mut EventWriter<UserUpdatedComponentsEvent>,
+    components_updated_writer: &mut MessageWriter<UserUpdatedComponentsEvent>,
 ) {
     // Always update UI when entity changes
     if cache.dirty.entity_dirty {
@@ -57,7 +57,7 @@ pub fn update_components_from_cache(
 pub fn update_transform_from_cache(
     global_transform_data: &mut EntityGlobalTransformData,
     cache: &mut ResMut<EntityUIDataCache>,
-    transform_updated_writer: &mut EventWriter<UserUpdatedTransformEvent>,
+    transform_updated_writer: &mut MessageWriter<UserUpdatedTransformEvent>,
 ) {
     if cache.dirty.entity_dirty {
         global_transform_data.clear();
@@ -89,7 +89,7 @@ pub fn update_transform_from_cache(
 pub fn update_identity_from_cache(
     identity_data: &mut EntityIdentityData,
     cache: &mut ResMut<EntityUIDataCache>,
-    identity_updated_writer: &mut EventWriter<UserUpdatedIdentityEvent>,
+    identity_updated_writer: &mut MessageWriter<UserUpdatedIdentityEvent>,
 ) {
     if cache.dirty.identity_dirty && !identity_data.name_changed {
         identity_data.name = cache.data.identity.name.to_string();
@@ -114,7 +114,7 @@ pub fn update_identity_from_cache(
 pub fn send_component_events_from_ui_change(
     registered_data: &mut EntityRegisteredData,
     cache: &mut ResMut<EntityUIDataCache>,
-    components_updated_writer: &mut EventWriter<UserUpdatedComponentsEvent>,
+    components_updated_writer: &mut MessageWriter<UserUpdatedComponentsEvent>,
 ) {
     if let Some(entity) = cache.data.entity {
         components_updated_writer.write(UserUpdatedComponentsEvent {
@@ -132,7 +132,7 @@ pub fn send_component_events_from_ui_change(
 pub fn send_transform_events_from_ui_change(
     global_transform_data: &mut EntityGlobalTransformData,
     cache: &mut ResMut<EntityUIDataCache>,
-    transform_updated_writer: &mut EventWriter<UserUpdatedTransformEvent>,
+    transform_updated_writer: &mut MessageWriter<UserUpdatedTransformEvent>,
 ) {
     if global_transform_data.transform_data_changed {
         if let Some(entity) = cache.data.entity {
@@ -150,7 +150,7 @@ pub fn send_transform_events_from_ui_change(
 pub fn send_identity_events_from_ui_change(
     identity_data: &mut EntityIdentityData,
     cache: &mut ResMut<EntityUIDataCache>,
-    identity_updated_writer: &mut EventWriter<UserUpdatedIdentityEvent>,
+    identity_updated_writer: &mut MessageWriter<UserUpdatedIdentityEvent>,
 ) {
     if identity_data.name_changed || identity_data.class_data_changed {
         if let Some(entity) = cache.data.entity {

--- a/crates/bevy_granite_editor/src/interface/events.rs
+++ b/crates/bevy_granite_editor/src/interface/events.rs
@@ -2,9 +2,9 @@ use crate::interface::popups::PopupType;
 use crate::interface::tabs::entity_editor::{
     EntityGlobalTransformData, EntityIdentityData, EntityRegisteredData,
 };
-use bevy::ecs::event::EventWriter;
+use bevy::ecs::message::MessageWriter;
 use bevy::ecs::system::SystemParam;
-use bevy::prelude::{Entity, Event, Vec2};
+use bevy::prelude::{Entity, Message, Vec2};
 use bevy_granite_core::RequestDespawnBySource;
 use bevy_granite_core::RequestDespawnSerializableEntities;
 use bevy_granite_core::{EditableMaterial, GraniteTypes};
@@ -12,61 +12,61 @@ use bevy_granite_core::{RequestLoadEvent, RequestReloadEvent, RequestSaveEvent};
 
 #[derive(SystemParam)]
 pub struct EditorEvents<'w> {
-    pub popup: EventWriter<'w, PopupMenuRequestedEvent>,
-    pub save: EventWriter<'w, RequestSaveEvent>,
-    pub reload: EventWriter<'w, RequestReloadEvent>,
-    pub load: EventWriter<'w, RequestLoadEvent>,
-    pub toggle_editor: EventWriter<'w, RequestEditorToggle>,
-    pub toggle_cam_sync: EventWriter<'w, RequestToggleCameraSync>,
-    pub frame: EventWriter<'w, RequestCameraEntityFrame>,
-    pub parent: EventWriter<'w, RequestNewParent>,
-    pub remove_parent: EventWriter<'w, RequestRemoveParents>,
-    pub remove_parent_entities: EventWriter<'w, RequestRemoveParentsFromEntities>,
-    pub remove_children: EventWriter<'w, RequestRemoveChildren>,
-    pub despawn_all: EventWriter<'w, RequestDespawnSerializableEntities>,
-    pub despawn_by_source: EventWriter<'w, RequestDespawnBySource>,
-    pub set_active_world: EventWriter<'w, SetActiveWorld>,
+    pub popup: MessageWriter<'w, PopupMenuRequestedEvent>,
+    pub save: MessageWriter<'w, RequestSaveEvent>,
+    pub reload: MessageWriter<'w, RequestReloadEvent>,
+    pub load: MessageWriter<'w, RequestLoadEvent>,
+    pub toggle_editor: MessageWriter<'w, RequestEditorToggle>,
+    pub toggle_cam_sync: MessageWriter<'w, RequestToggleCameraSync>,
+    pub frame: MessageWriter<'w, RequestCameraEntityFrame>,
+    pub parent: MessageWriter<'w, RequestNewParent>,
+    pub remove_parent: MessageWriter<'w, RequestRemoveParents>,
+    pub remove_parent_entities: MessageWriter<'w, RequestRemoveParentsFromEntities>,
+    pub remove_children: MessageWriter<'w, RequestRemoveChildren>,
+    pub despawn_all: MessageWriter<'w, RequestDespawnSerializableEntities>,
+    pub despawn_by_source: MessageWriter<'w, RequestDespawnBySource>,
+    pub set_active_world: MessageWriter<'w, SetActiveWorld>,
 }
 
 // Internal Events
 
-#[derive(Event)]
+#[derive(Message)]
 pub struct UserUpdatedComponentsEvent {
     pub entity: Entity,
     pub data: EntityRegisteredData,
 }
 
-#[derive(Event)]
+#[derive(Message)]
 pub struct UserUpdatedIdentityEvent {
     pub entity: Entity,
     pub data: EntityIdentityData,
 }
 
-#[derive(Event)]
+#[derive(Message)]
 pub struct UserUpdatedTransformEvent {
     pub entity: Entity,
     pub data: EntityGlobalTransformData,
 }
 
 // Need to change this to the actual data struct instead. No need to have both structs
-#[derive(Event)]
+#[derive(Message)]
 pub struct UserRequestGraniteTypeViaPopup {
     pub class: GraniteTypes,
 }
 
-#[derive(Event)]
+#[derive(Message)]
 pub struct UserRequestedRelationShipEvent;
 
-#[derive(Event)]
+#[derive(Message)]
 pub struct SetActiveWorld(pub String);
 
-#[derive(Event)]
+#[derive(Message)]
 pub struct PopupMenuRequestedEvent {
     pub popup: PopupType,
     pub mouse_pos: Vec2,
 }
 
-#[derive(Event)]
+#[derive(Message)]
 pub struct MaterialHandleUpdateEvent {
     pub skip_entity: Entity, // Requestor
     pub path: String,        // Path of updated EditableMaterial
@@ -74,32 +74,32 @@ pub struct MaterialHandleUpdateEvent {
     pub material: EditableMaterial,
 }
 
-#[derive(Event)]
+#[derive(Message)]
 pub struct MaterialDeleteEvent {
     pub path: String,
 }
 
 // User callable events
 
-#[derive(Event)]
+#[derive(Message)]
 pub struct RequestEditorToggle;
 
-#[derive(Event)]
+#[derive(Message)]
 pub struct RequestCameraEntityFrame;
 
-#[derive(Event)]
+#[derive(Message)]
 pub struct RequestToggleCameraSync;
 
-#[derive(Event)]
+#[derive(Message)]
 pub struct RequestNewParent;
 
-#[derive(Event)]
+#[derive(Message)]
 pub struct RequestRemoveParents;
 
-#[derive(Event)]
+#[derive(Message)]
 pub struct RequestRemoveParentsFromEntities {
     pub entities: Vec<Entity>,
 }
 
-#[derive(Event)]
+#[derive(Message)]
 pub struct RequestRemoveChildren;

--- a/crates/bevy_granite_editor/src/interface/layout/dock.rs
+++ b/crates/bevy_granite_editor/src/interface/layout/dock.rs
@@ -12,7 +12,11 @@ use crate::{
 };
 
 use bevy::{
-    ecs::system::Commands,
+    camera::Camera,
+    ecs::{
+        query::With,
+        system::{Commands, Query, Single},
+    },
     prelude::{Res, ResMut},
 };
 use bevy_egui::{egui, EguiContexts};
@@ -54,6 +58,7 @@ pub fn dock_ui_system(
     editor_state: Res<EditorState>,
     user_input: Res<UserInput>,
     mut commands: Commands,
+    mut view_port: Query<&mut Camera, With<crate::ViewPortCamera>>,
 ) {
     let ctx = contexts.ctx_mut().expect("Egui context to exist");
     let screen_rect = ctx.screen_rect();
@@ -64,7 +69,7 @@ pub fn dock_ui_system(
     let bottom_panel_height = (screen_height * 0.05).clamp(100., 400.);
 
     let space = get_interface_config_float("ui.spacing");
-
+    let mut left = false;
     egui::TopBottomPanel::top("tool_panel")
         .resizable(false)
         .show(ctx, |ui| {
@@ -84,6 +89,7 @@ pub fn dock_ui_system(
     let side_panel_position = editor_state.config.dock.side_panel_position;
     match side_panel_position {
         SidePanelPosition::Left => {
+            left = true;
             egui::SidePanel::left("left_dock_panel")
                 .resizable(true)
                 .default_width(right_panel_width)
@@ -117,4 +123,20 @@ pub fn dock_ui_system(
                 .id(egui::Id::new("bottom_dock_area"))
                 .show_inside(ui, &mut BottomTabViewer);
         });
+
+    let size = ctx.available_rect();
+    for mut camera in view_port.iter_mut() {
+        let width = (size.width() * 1.5) as u32;
+        let height = (size.height() * 1.5) as u32;
+        let Some(viewport) = camera.viewport.as_mut() else {
+            continue;
+        };
+        if left {
+            viewport.physical_position.x = screen_width as u32 - width;
+        } else {
+            viewport.physical_position.x = 0;
+        }
+        viewport.physical_position.y = (size.min.y * 1.5) as u32;
+        viewport.physical_size = bevy::prelude::UVec2::new(width, height);
+    }
 }

--- a/crates/bevy_granite_editor/src/interface/layout/top_bar.rs
+++ b/crates/bevy_granite_editor/src/interface/layout/top_bar.rs
@@ -24,7 +24,7 @@ use bevy_granite_core::{
     absolute_asset_to_rel, entities::SaveSettings, RequestDespawnBySource,
     RequestDespawnSerializableEntities, RequestLoadEvent, RequestSaveEvent, UserInput,
 };
-use bevy_granite_gizmos::selection::events::EntityEvent;
+use bevy_granite_gizmos::selection::events::EntityEvents;
 use native_dialog::FileDialog;
 
 pub fn top_bar_ui(
@@ -292,7 +292,7 @@ pub fn top_bar_ui(
             }
             ui.separator();
             if ui.button("Deselect All (U) ").clicked() {
-                commands.trigger(EntityEvent::DeselectAll);
+                commands.trigger(EntityEvents::DeselectAll);
             }
             ui.separator();
         });

--- a/crates/bevy_granite_editor/src/interface/plugin.rs
+++ b/crates/bevy_granite_editor/src/interface/plugin.rs
@@ -33,23 +33,23 @@ impl Plugin for InterfacePlugin {
             //
             // Interface events
             //
-            .add_event::<MaterialHandleUpdateEvent>()
-            .add_event::<MaterialDeleteEvent>()
-            .add_event::<UserUpdatedComponentsEvent>()
-            .add_event::<UserUpdatedTransformEvent>()
-            .add_event::<UserUpdatedIdentityEvent>()
-            .add_event::<UserRequestGraniteTypeViaPopup>()
-            .add_event::<PopupMenuRequestedEvent>()
-            .add_event::<RequestEditorToggle>()
-            .add_event::<RequestCameraEntityFrame>()
-            .add_event::<RequestToggleCameraSync>()
-            .add_event::<RequestNewParent>()
-            .add_event::<RequestRemoveChildren>()
-            .add_event::<RequestRemoveParents>()
-            .add_event::<SetActiveWorld>()
+            .add_message::<MaterialHandleUpdateEvent>()
+            .add_message::<MaterialDeleteEvent>()
+            .add_message::<UserUpdatedComponentsEvent>()
+            .add_message::<UserUpdatedTransformEvent>()
+            .add_message::<UserUpdatedIdentityEvent>()
+            .add_message::<UserRequestGraniteTypeViaPopup>()
+            .add_message::<PopupMenuRequestedEvent>()
+            .add_message::<RequestEditorToggle>()
+            .add_message::<RequestCameraEntityFrame>()
+            .add_message::<RequestToggleCameraSync>()
+            .add_message::<RequestNewParent>()
+            .add_message::<RequestRemoveChildren>()
+            .add_message::<RequestRemoveParents>()
+            .add_message::<SetActiveWorld>()
             // need to rework
-            .add_event::<RequestReparentEntityEvent>()
-            .add_event::<RequestRemoveParentsFromEntities>()
+            .add_message::<RequestReparentEntityEvent>()
+            .add_message::<RequestRemoveParentsFromEntities>()
             //
             // Register types
             // If you want to duplicate bevy data you must register the type

--- a/crates/bevy_granite_editor/src/interface/popups/add_entity_ui.rs
+++ b/crates/bevy_granite_editor/src/interface/popups/add_entity_ui.rs
@@ -4,7 +4,7 @@ use crate::{
     },
     UI_CONFIG,
 };
-use bevy::{ecs::event::EventWriter, prelude::Vec2};
+use bevy::{ecs::message::MessageWriter, prelude::Vec2};
 use bevy_egui::{
     egui::{self, Window},
     EguiContexts,
@@ -16,7 +16,7 @@ use bevy_granite_core::{ClassCategory, GraniteType, GraniteTypes};
 pub fn add_entity_ui(
     contexts: &mut EguiContexts,
     position: Vec2,
-    mut entity_add_request: EventWriter<UserRequestGraniteTypeViaPopup>,
+    mut entity_add_request: MessageWriter<UserRequestGraniteTypeViaPopup>,
 ) -> bool {
     let mut should_close = false;
 

--- a/crates/bevy_granite_editor/src/interface/popups/popup_requested_system.rs
+++ b/crates/bevy_granite_editor/src/interface/popups/popup_requested_system.rs
@@ -1,6 +1,6 @@
 use bevy::{
     ecs::{
-        event::{EventReader, EventWriter},
+        message::{MessageReader, MessageWriter},
         query::With,
         system::{Query, ResMut},
     },
@@ -36,7 +36,7 @@ pub struct PopupState {
 }
 
 pub fn handle_popup_requests_system(
-    mut popup_reader: EventReader<PopupMenuRequestedEvent>,
+    mut popup_reader: MessageReader<PopupMenuRequestedEvent>,
     mut popup_state: ResMut<PopupState>,
 ) {
     for PopupMenuRequestedEvent { popup, mouse_pos } in popup_reader.read() {
@@ -56,7 +56,7 @@ pub fn show_active_popups_system(
     mut contexts: EguiContexts,
     mut popup_state: ResMut<PopupState>,
     events: EditorEvents,
-    entity_add_writer: EventWriter<UserRequestGraniteTypeViaPopup>,
+    entity_add_writer: MessageWriter<UserRequestGraniteTypeViaPopup>,
     window_query: Query<&Window, With<PrimaryWindow>>,
     editor_state: ResMut<EditorState>,
 ) {

--- a/crates/bevy_granite_editor/src/interface/tabs/entity_editor/systems/entity_updates.rs
+++ b/crates/bevy_granite_editor/src/interface/tabs/entity_editor/systems/entity_updates.rs
@@ -26,7 +26,7 @@ use bevy::{
     },
 };
 use bevy_granite_core::{
-    entities::{editable::RequestEntityUpdateFromClass, GraniteType},
+    entities::{editable::RequestEntityUpdateFromClass, GraniteType, Unknown},
     AvailableEditableMaterials, ComponentEditor, EditableMaterial, EditableMaterialError,
     EditableMaterialField, IdentityData, StandardMaterialDef,
 };
@@ -120,10 +120,10 @@ pub fn update_entity_with_new_identity_system(
     {
         for (
             entity,
-            mut name,
+            name,
             _transform,
             _global_transform,
-            mut identity_data,
+            identity_data_ref,
             mut material_handle,
             _active,
         ) in query.iter_mut()
@@ -137,6 +137,18 @@ pub fn update_entity_with_new_identity_system(
                 );
                 continue;
             }
+
+            let mut identity_data = if let Some(data) = identity_data_ref.as_ref() {
+                data.as_ref().clone()
+            } else {
+                IdentityData {
+                    class: bevy_granite_core::GraniteTypes::Unknown(Unknown::default()),
+                    uuid: uuid::Uuid::new_v4(),
+                    name: name
+                        .map(|n| n.to_string())
+                        .unwrap_or(format!("Entity {:?}", entity)),
+                }
+            };
 
             // Only update materials when there are actual changes, not any change
             let needs_mat_update =
@@ -159,7 +171,9 @@ pub fn update_entity_with_new_identity_system(
 
             if needs_entity_name_update {
                 identity_data.name = update_data.name.clone();
-                *name = Name::new(update_data.name.clone());
+                commands
+                    .entity(entity)
+                    .insert(Name::new(update_data.name.clone()));
 
                 log!(
                     LogType::Editor,
@@ -226,6 +240,10 @@ pub fn update_entity_with_new_identity_system(
                         &mut material_handle_update_writer,
                     );
                 }
+            }
+
+            if let Some(mut data) = identity_data_ref {
+                *data = identity_data;
             }
         }
     }

--- a/crates/bevy_granite_editor/src/interface/tabs/entity_editor/systems/entity_updates.rs
+++ b/crates/bevy_granite_editor/src/interface/tabs/entity_editor/systems/entity_updates.rs
@@ -20,7 +20,7 @@ use bevy::{
 use bevy::{
     asset::Assets,
     ecs::{
-        event::{EventReader, EventWriter},
+        message::{MessageReader, MessageWriter},
         query::Without,
         system::{Query, Res, ResMut},
     },
@@ -49,7 +49,7 @@ use bevy_granite_logging::{
 // Request to change the entity transform, update the entity transform, and inverse the gizmo rotation
 // so it doesn't move with the new rotation
 pub fn update_entity_with_new_transform_system(
-    mut transform_updated_reader: EventReader<UserUpdatedTransformEvent>,
+    mut transform_updated_reader: MessageReader<UserUpdatedTransformEvent>,
     mut e_query: Query<
         (Entity, &mut Transform, &GlobalTransform, Option<&ChildOf>),
         (Without<GizmoChildren>, With<IdentityData>),
@@ -105,8 +105,8 @@ pub fn update_entity_with_new_transform_system(
 
 pub fn update_entity_with_new_identity_system(
     mut commands: Commands,
-    mut identity_updated_reader: EventReader<UserUpdatedIdentityEvent>,
-    mut material_handle_update_writer: EventWriter<MaterialHandleUpdateEvent>,
+    mut identity_updated_reader: MessageReader<UserUpdatedIdentityEvent>,
+    mut material_handle_update_writer: MessageWriter<MaterialHandleUpdateEvent>,
     mut request_writer: RequestEntityUpdateFromClass,
     mut query: Query<EntityCacheQueryItem>,
     mut materials: ResMut<Assets<StandardMaterial>>,
@@ -243,7 +243,7 @@ fn handle_material_update(
     materials: &mut ResMut<Assets<StandardMaterial>>,
     available_obj_materials: &mut ResMut<AvailableEditableMaterials>,
     asset_server: &Res<AssetServer>,
-    material_handle_update_writer: &mut EventWriter<MaterialHandleUpdateEvent>,
+    material_handle_update_writer: &mut MessageWriter<MaterialHandleUpdateEvent>,
 ) {
     if !material.disk_changes && !needs_mat_update {
         log!(
@@ -410,7 +410,7 @@ fn handle_material_update(
 }
 
 pub fn update_entity_with_new_components_system(
-    mut components_updated_reader: EventReader<UserUpdatedComponentsEvent>,
+    mut components_updated_reader: MessageReader<UserUpdatedComponentsEvent>,
     mut commands: Commands,
 ) {
     for UserUpdatedComponentsEvent { entity, data } in components_updated_reader.read() {
@@ -471,7 +471,7 @@ fn handle_component_update(
 }
 
 pub fn handle_material_deletion_system(
-    mut material_delete_reader: EventReader<MaterialDeleteEvent>,
+    mut material_delete_reader: MessageReader<MaterialDeleteEvent>,
     available_materials: Res<AvailableEditableMaterials>,
     mut identity_query: Query<(Entity, &mut IdentityData)>,
     mut commands: Commands,

--- a/crates/bevy_granite_editor/src/interface/tabs/entity_editor/systems/material_sync.rs
+++ b/crates/bevy_granite_editor/src/interface/tabs/entity_editor/systems/material_sync.rs
@@ -1,6 +1,6 @@
 use crate::interface::events::MaterialHandleUpdateEvent;
 use bevy::{
-    ecs::{entity::Entity, event::EventReader, system::Query},
+    ecs::{entity::Entity, message::MessageReader, system::Query},
     prelude::ResMut,
 };
 use bevy_granite_core::{entities::GraniteType, AvailableEditableMaterials, IdentityData};
@@ -10,7 +10,7 @@ use bevy_granite_logging::{
 };
 
 pub fn update_material_handle_system(
-    mut material_handle_update_reader: EventReader<MaterialHandleUpdateEvent>,
+    mut material_handle_update_reader: MessageReader<MaterialHandleUpdateEvent>,
     mut _available_materials: ResMut<AvailableEditableMaterials>,
     mut identity_query: Query<(Entity, &mut IdentityData)>,
 ) {

--- a/crates/bevy_granite_editor/src/interface/tabs/entity_editor/systems/tab_updates.rs
+++ b/crates/bevy_granite_editor/src/interface/tabs/entity_editor/systems/tab_updates.rs
@@ -13,7 +13,7 @@ use crate::interface::{
 use bevy::ecs::{
     change_detection::DetectChanges,
     entity::Entity,
-    event::EventWriter,
+    message::MessageWriter,
     query::With,
     system::{Query, Res, ResMut},
 };
@@ -29,10 +29,10 @@ pub fn update_entity_editor_tab_system(
     type_names: Res<RegisteredTypeNames>,
     mut available_materials: ResMut<AvailableEditableMaterials>,
     mut active_entity: Query<Entity, With<ActiveSelection>>,
-    mut identity_updated_writer: EventWriter<UserUpdatedIdentityEvent>,
-    mut transform_updated_writer: EventWriter<UserUpdatedTransformEvent>,
-    mut component_updated_writer: EventWriter<UserUpdatedComponentsEvent>,
-    mut material_delete_writer: EventWriter<MaterialDeleteEvent>,
+    mut identity_updated_writer: MessageWriter<UserUpdatedIdentityEvent>,
+    mut transform_updated_writer: MessageWriter<UserUpdatedTransformEvent>,
+    mut component_updated_writer: MessageWriter<UserUpdatedComponentsEvent>,
+    mut material_delete_writer: MessageWriter<MaterialDeleteEvent>,
     global_component_editor: ResMut<ComponentEditor>,
 ) {
     for (_, tab) in right_dock.dock_state.iter_all_tabs_mut() {

--- a/crates/bevy_granite_editor/src/interface/tabs/node_tree/hierarchy.rs
+++ b/crates/bevy_granite_editor/src/interface/tabs/node_tree/hierarchy.rs
@@ -175,7 +175,9 @@ fn create_stable_dummy_entity(file_path: &str) -> Entity {
     for byte in file_path.bytes() {
         hash = hash.wrapping_mul(33).wrapping_add(byte as u32);
     }
-    Entity::from_raw(u32::MAX - (hash % 1000000))
+    hash %= 1000000;
+    hash += 1; // Ensure non-zero to avoid Entity::from_raw_u32(u32::MAX)
+    Entity::from_raw_u32(u32::MAX - hash).expect("u32::Max - anything is valid entity")
 }
 
 /// Sorts the hierarchy for consistent display order

--- a/crates/bevy_granite_editor/src/interface/tabs/node_tree/selection.rs
+++ b/crates/bevy_granite_editor/src/interface/tabs/node_tree/selection.rs
@@ -1,7 +1,7 @@
 use super::data::{HierarchyEntry, NodeTreeTabData};
 use super::hierarchy::build_visual_order;
 use bevy::prelude::Entity;
-use bevy_granite_gizmos::selection::events::EntityEvent;
+use bevy_granite_gizmos::selection::events::EntityEvents;
 use bevy_granite_logging::{log, LogCategory, LogLevel, LogType};
 
 /// Validation functions for drag and drop operations
@@ -84,7 +84,7 @@ pub fn process_selection_changes(
                 if let Some(prev_active) = data.active_selection {
                     perform_range_selection(prev_active, new_selection, data, commands);
                 } else {
-                    commands.trigger(EntityEvent::Select {
+                    commands.trigger(EntityEvents::Select {
                         target: new_selection,
                         additive: false,
                     });
@@ -95,11 +95,11 @@ pub fn process_selection_changes(
                 // Toggle selection
                 let already_selected = data.selected_entities.contains(&new_selection);
                 if already_selected {
-                    commands.trigger(EntityEvent::Deselect {
+                    commands.trigger(EntityEvents::Deselect {
                         target: new_selection,
                     });
                 } else {
-                    commands.trigger(EntityEvent::Select {
+                    commands.trigger(EntityEvents::Select {
                         target: new_selection,
                         additive: true,
                     });
@@ -108,7 +108,7 @@ pub fn process_selection_changes(
                 data.active_selection = Some(new_selection);
             } else {
                 // Normal selection
-                commands.trigger(EntityEvent::Select {
+                commands.trigger(EntityEvents::Select {
                     target: new_selection,
                     additive: false,
                 });
@@ -277,13 +277,13 @@ fn perform_range_selection(
         let min_idx = start_idx.min(end_idx);
         let max_idx = start_idx.max(end_idx);
 
-        commands.trigger(EntityEvent::Select {
+        commands.trigger(EntityEvents::Select {
             target: start_entity,
             additive: true,
         });
 
         for i in min_idx..=max_idx {
-            commands.trigger(EntityEvent::Select {
+            commands.trigger(EntityEvents::Select {
                 target: visual_order[i],
                 additive: true,
             });

--- a/crates/bevy_granite_editor/src/interface/tabs/node_tree/system.rs
+++ b/crates/bevy_granite_editor/src/interface/tabs/node_tree/system.rs
@@ -17,7 +17,7 @@ use bevy::ecs::query::Has;
 use bevy::ecs::system::Commands;
 use bevy::{
     ecs::query::{Changed, Or},
-    prelude::{ChildOf, Entity, EventWriter, Name, Query, Res, ResMut, With, RemovedComponents},
+    prelude::{ChildOf, Entity, MessageWriter, Name, Query, Res, ResMut, With, RemovedComponents},
 };
 use bevy_granite_core::{
     IdentityData, RequestDespawnBySource, RequestReloadEvent, SpawnSource, TreeHiddenEntity,
@@ -45,7 +45,7 @@ pub fn update_node_tree_tabs_system(
     mut removed_child_of: RemovedComponents<ChildOf>,
     mut commands: Commands,
     mut editor_events: EditorEvents,
-    mut reparent_event_writer: EventWriter<RequestReparentEntityEvent>,
+    mut reparent_event_writer: MessageWriter<RequestReparentEntityEvent>,
 ) {
     for (_, tab) in right_dock.dock_state.iter_all_tabs_mut() {
         if let SideTab::NodeTree { ref mut data, .. } = tab {
@@ -98,8 +98,8 @@ pub fn update_node_tree_tabs_system(
 
 fn handle_drag_drop_events(
     data: &mut crate::interface::tabs::NodeTreeTabData,
-    reparent_event_writer: &mut EventWriter<RequestReparentEntityEvent>,
-    remove_parents_event_writer: &mut EventWriter<RequestRemoveParentsFromEntities>,
+    reparent_event_writer: &mut MessageWriter<RequestReparentEntityEvent>,
+    remove_parents_event_writer: &mut MessageWriter<RequestRemoveParentsFromEntities>,
 ) {
     if let Some(dragged_entities) = data.drag_payload.clone() {
         if let Some(drop_target) = data.drop_target {

--- a/crates/bevy_granite_editor/src/lib.rs
+++ b/crates/bevy_granite_editor/src/lib.rs
@@ -55,3 +55,8 @@ impl Plugin for BevyGraniteEditor {
         app.add_plugins(bevy_granite_expose::BevyGraniteExposePlugin); // this will register internal bevy components so they can be used in the editor
     }
 }
+
+/// Marker component for the camera used as the editor viewport
+/// IDK whats with egui it seems to eat the normal view of the camera
+#[derive(Component)]
+pub struct ViewPortCamera;

--- a/crates/bevy_granite_editor/src/viewport/camera/system.rs
+++ b/crates/bevy_granite_editor/src/viewport/camera/system.rs
@@ -8,13 +8,13 @@ use bevy::{
     asset::Assets,
     ecs::entity::Entity,
     input::mouse::{MouseMotion, MouseWheel},
+    mesh::{Mesh, Mesh3d},
     prelude::{
-        EventReader, Local, Query, Res, ResMut, Resource, Time, Transform, Vec2, Vec3, Window,
+        Local, MessageReader, Query, Res, ResMut, Resource, Time, Transform, Vec2, Vec3, Window,
         With, Without,
     },
-    render::mesh::{Mesh, Mesh3d},
     transform::components::GlobalTransform,
-    window::{CursorGrabMode, PrimaryWindow},
+    window::{CursorGrabMode, CursorOptions, PrimaryWindow},
 };
 use bevy_granite_core::{MainCamera, UICamera, UserInput};
 use bevy_granite_gizmos::{ActiveSelection, DragState, Selected};
@@ -81,7 +81,7 @@ pub fn sync_cameras_system(
 
 // Whether or not we want control of main camera
 pub fn camera_sync_toggle_system(
-    mut toggle_event_writer: EventReader<RequestToggleCameraSync>,
+    mut toggle_event_writer: MessageReader<RequestToggleCameraSync>,
     mut sync: ResMut<CameraSyncState>,
     ui_camera_query: Query<&Transform, With<UICamera>>,
 ) {
@@ -107,7 +107,7 @@ pub fn camera_frame_system(
     transform_query: Query<&GlobalTransform, Without<UICamera>>,
     mut camera_query: Query<&mut Transform, With<UICamera>>,
     mut camera_target: ResMut<CameraTarget>,
-    mut frame_reader: EventReader<RequestCameraEntityFrame>,
+    mut frame_reader: MessageReader<RequestCameraEntityFrame>,
     _user_input: Res<UserInput>,
     selected_query: Query<Entity, With<Selected>>,
     active_query: Query<Entity, With<ActiveSelection>>,
@@ -248,9 +248,9 @@ pub fn camera_frame_system(
 // FIX:
 // use new UserInput
 pub fn mouse_button_iter(
-    mut primary_window: Query<&mut Window, With<PrimaryWindow>>,
-    mut mouse_motion_events: EventReader<MouseMotion>,
-    mut mouse_wheel_events: EventReader<MouseWheel>,
+    mut primary_window: Query<(&mut Window, &mut CursorOptions), With<PrimaryWindow>>,
+    mut mouse_motion_events: MessageReader<MouseMotion>,
+    mut mouse_wheel_events: MessageReader<MouseWheel>,
     mut query: Query<&mut Transform, With<UICamera>>,
     mut input_state: ResMut<InputState>,
     time: Res<Time>,
@@ -263,16 +263,16 @@ pub fn mouse_button_iter(
         return;
     }
 
-    if let Ok(mut window) = primary_window.single_mut() {
+    if let Ok((mut window, mut cursor_options)) = primary_window.single_mut() {
         if user_input.mouse_right.just_pressed {
-            window.cursor_options.visible = false;
-            window.cursor_options.grab_mode = CursorGrabMode::Locked;
+            cursor_options.visible = false;
+            cursor_options.grab_mode = CursorGrabMode::Locked;
             input_state.initial_cursor_pos = window.cursor_position();
         }
 
         if user_input.mouse_right.just_released {
-            window.cursor_options.visible = true;
-            window.cursor_options.grab_mode = CursorGrabMode::None;
+            cursor_options.visible = true;
+            cursor_options.grab_mode = CursorGrabMode::None;
             if let Some(pos) = input_state.initial_cursor_pos {
                 window.set_cursor_position(Some(pos));
             }
@@ -308,7 +308,7 @@ pub fn mouse_button_iter(
 fn handle_pan_or_rotation(
     query: &mut Query<&mut Transform, With<UICamera>>,
     user_input: &Res<UserInput>,
-    mouse_motion_events: &mut EventReader<MouseMotion>,
+    mouse_motion_events: &mut MessageReader<MouseMotion>,
     target_pos: &mut ResMut<CameraTarget>,
     delta_time: f32,
 ) {

--- a/crates/bevy_granite_editor/src/viewport/camera/utils.rs
+++ b/crates/bevy_granite_editor/src/viewport/camera/utils.rs
@@ -1,13 +1,13 @@
 use crate::{editor_state::INPUT_CONFIG, viewport::camera::CameraTarget};
+use bevy::camera::visibility::RenderLayers;
 use bevy::core_pipeline::tonemapping::Tonemapping;
 use bevy::{
-    core_pipeline::core_3d::Camera3d,
+    camera::Camera3d,
     input::mouse::{MouseMotion, MouseWheel},
     prelude::{
-        Camera, Commands, EulerRot, EventReader, Local, Name, Quat, Query, Res, ResMut, Time,
+        Camera, Commands, EulerRot, Local, MessageReader, Name, Quat, Query, Res, ResMut, Time,
         Transform, Vec2, Vec3, With,
     },
-    render::view::RenderLayers,
 };
 use bevy_granite_core::{EditorIgnore, TreeHiddenEntity, UICamera, UserInput};
 
@@ -56,8 +56,8 @@ pub fn rotate_camera_towards(
 pub fn handle_movement(
     query: &mut Query<&mut Transform, With<UICamera>>,
     user_input: &Res<UserInput>,
-    mouse_motion_events: &mut EventReader<MouseMotion>,
-    mouse_wheel_events: &mut EventReader<MouseWheel>,
+    mouse_motion_events: &mut MessageReader<MouseMotion>,
+    mouse_wheel_events: &mut MessageReader<MouseWheel>,
     _target_pos: &mut ResMut<CameraTarget>,
     time: Res<Time>,
     mut movement_speed: Local<f32>,
@@ -122,7 +122,7 @@ pub fn handle_movement(
 
 pub fn handle_zoom(
     query: &mut Query<&mut Transform, With<UICamera>>,
-    mouse_wheel_events: &mut EventReader<MouseWheel>,
+    mouse_wheel_events: &mut MessageReader<MouseWheel>,
     target_pos: &mut ResMut<CameraTarget>,
 ) {
     let zoom_speed = INPUT_CONFIG.zoom_camera_sensitivity;

--- a/crates/bevy_granite_editor/src/viewport/camera/utils.rs
+++ b/crates/bevy_granite_editor/src/viewport/camera/utils.rs
@@ -1,5 +1,6 @@
 use crate::{editor_state::INPUT_CONFIG, viewport::camera::CameraTarget};
 use bevy::camera::visibility::RenderLayers;
+use bevy::camera::Viewport;
 use bevy::core_pipeline::tonemapping::Tonemapping;
 use bevy::{
     camera::Camera3d,
@@ -36,6 +37,20 @@ pub fn add_ui_camera(mut commands: Commands) {
         .insert(TreeHiddenEntity)
         .insert(bevy_granite_gizmos::GizmoCamera)
         .insert(RenderLayers::layer(14)) // 14 is our UI/Gizmo layer.
+        .with_child((
+            Camera3d::default(),
+            crate::ViewPortCamera,
+            Tonemapping::None,
+            Camera {
+                order: 3,
+                viewport: Some(Viewport {
+                    physical_position: (0, 0).into(),
+                    physical_size: (400, 400).into(),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        ))
         .id();
 }
 

--- a/crates/bevy_granite_editor/src/viewport/debug/cameras.rs
+++ b/crates/bevy_granite_editor/src/viewport/debug/cameras.rs
@@ -1,11 +1,11 @@
 use super::DebugRenderer;
 use crate::editor_state::EditorState;
 use bevy::{
+    camera::Camera,
     color::Color,
     ecs::{entity::Entity, system::Query},
     gizmos::gizmos::Gizmos,
     prelude::{Res, With, Without},
-    render::camera::Camera,
     transform::components::GlobalTransform,
 };
 use bevy_granite_core::MainCamera;

--- a/crates/bevy_granite_editor/src/viewport/debug/lights.rs
+++ b/crates/bevy_granite_editor/src/viewport/debug/lights.rs
@@ -4,7 +4,7 @@ use bevy::{
     color::Color,
     ecs::{entity::Entity, system::Query},
     gizmos::gizmos::Gizmos,
-    pbr::{DirectionalLight, PointLight},
+    light::{DirectionalLight, PointLight},
     prelude::{Res, With},
     transform::components::GlobalTransform,
 };

--- a/crates/bevy_granite_editor/src/viewport/debug/selection.rs
+++ b/crates/bevy_granite_editor/src/viewport/debug/selection.rs
@@ -7,7 +7,7 @@ use bevy::{
     gizmos::gizmos::Gizmos,
     math::Vec3,
     prelude::{Assets, Mesh, Res, With},
-    render::mesh::Mesh3d,
+    mesh::Mesh3d,
     transform::components::GlobalTransform,
 };
 use bevy_granite_core::IdentityData;

--- a/crates/bevy_granite_editor/src/viewport/icons/mod.rs
+++ b/crates/bevy_granite_editor/src/viewport/icons/mod.rs
@@ -8,7 +8,7 @@ use bevy::{
     image::Image,
     pbr::{MeshMaterial3d, StandardMaterial},
     prelude::{Bundle, Name},
-    render::mesh::Mesh3d,
+    mesh::Mesh3d,
 };
 use bevy_granite_core::{GraniteType, GraniteTypes, IconEntity};
 use bevy_granite_logging::{log, LogCategory, LogLevel, LogType};

--- a/crates/bevy_granite_editor/src/viewport/icons/spawning.rs
+++ b/crates/bevy_granite_editor/src/viewport/icons/spawning.rs
@@ -1,15 +1,14 @@
 use super::IconEntity;
 use crate::{editor_state::EditorState, viewport::config::VisualizationConfig};
 use bevy::{
-    pbr::{MeshMaterial3d, NotShadowCaster, NotShadowReceiver, StandardMaterial},
+    camera::visibility::RenderLayers,
+    light::{NotShadowCaster, NotShadowReceiver},
+    mesh::{Indices, Mesh3d},
+    pbr::{MeshMaterial3d, StandardMaterial},
     prelude::{
         Assets, Commands, Entity, Handle, Image, Mesh, Name, Query, Res, ResMut, Transform, Without,
     },
-    render::{
-        alpha::AlphaMode,
-        mesh::{Indices, Mesh3d},
-        view::RenderLayers,
-    },
+    render::alpha::AlphaMode,
 };
 use bevy_granite_core::{GraniteType, IconProxy, IdentityData, TreeHiddenEntity};
 

--- a/crates/bevy_granite_editor/src/viewport/icons/updating.rs
+++ b/crates/bevy_granite_editor/src/viewport/icons/updating.rs
@@ -1,17 +1,15 @@
 use super::IconEntity;
 use crate::editor_state::EditorState;
 use bevy::{
+    camera::visibility::Visibility,
     color::Color,
     math::Vec3,
     pbr::{MeshMaterial3d, StandardMaterial},
     prelude::{Assets, Entity, Query, Res, ResMut, Transform, With, Without},
-    render::view::Visibility,
     transform::components::GlobalTransform,
 };
 use bevy_granite_core::UICamera;
-use bevy_granite_gizmos::{
-    gizmos::NewGizmoType, ActiveSelection, DragState, GizmoType, Selected,
-};
+use bevy_granite_gizmos::{gizmos::NewGizmoType, ActiveSelection, DragState, GizmoType, Selected};
 
 pub fn update_icon_entities_system(
     mut icon_query: Query<

--- a/crates/bevy_granite_editor/src/viewport/plugin.rs
+++ b/crates/bevy_granite_editor/src/viewport/plugin.rs
@@ -15,14 +15,14 @@ use crate::{
 };
 use bevy::{
     app::{PostUpdate, Startup},
+    camera::visibility::RenderLayers,
     ecs::schedule::{ApplyDeferred, IntoScheduleConfigs},
     gizmos::{
         config::{DefaultGizmoConfigGroup, GizmoConfig},
         AppGizmoBuilder,
     },
     prelude::{App, Plugin, Update},
-    render::view::RenderLayers,
-    transform::TransformSystem,
+    transform::TransformSystems,
 };
 
 pub struct ViewportPlugin;
@@ -97,7 +97,7 @@ impl Plugin for ViewportPlugin {
                     show_active_selection_bounds_system,
                     show_selected_entities_bounds_system,
                 )
-                    .after(TransformSystem::TransformPropagate)
+                    .after(TransformSystems::Propagate)
                     .run_if(is_editor_active),
             )
             .add_systems(PostUpdate, sync_cameras_system.run_if(is_editor_active));

--- a/crates/bevy_granite_gizmos/src/camera.rs
+++ b/crates/bevy_granite_gizmos/src/camera.rs
@@ -83,7 +83,7 @@ pub fn add_gizmo_camera(
             })
             .insert(TreeHiddenEntity)
             .insert(GizmoCamera)
-            .insert(RenderLayers::layer(14)) // 14 is our UI/Gizmo layer.
+            .insert(RenderLayers::from_layers(&[0, 14])) // 14 is our UI/Gizmo layer.
             .id();
     }
 }

--- a/crates/bevy_granite_gizmos/src/camera.rs
+++ b/crates/bevy_granite_gizmos/src/camera.rs
@@ -1,14 +1,13 @@
 use bevy::{
-    core_pipeline::core_3d::Camera3d,
+    camera::{visibility::RenderLayers, Camera, Camera3d},
     ecs::{
         component::Component,
         entity::Entity,
-        event::{Event, EventReader, EventWriter},
+        message::{Message, MessageReader, MessageWriter},
         query::{Added, With, Without},
         system::{Commands, Query},
     },
     prelude::Name,
-    render::{camera::Camera, view::RenderLayers},
     transform::components::Transform,
 };
 use bevy_granite_core::{MainCamera, TreeHiddenEntity, UICamera};
@@ -20,12 +19,12 @@ use bevy_granite_logging::{
 #[derive(Component)]
 pub struct GizmoCamera;
 
-#[derive(Event)]
+#[derive(Message)]
 pub struct MainCameraAdded;
 
 pub fn watch_for_main_camera_addition(
     main_camera_added: Query<Entity, Added<MainCamera>>,
-    mut event_writer: EventWriter<MainCameraAdded>,
+    mut event_writer: MessageWriter<MainCameraAdded>,
 ) {
     if !main_camera_added.is_empty() {
         event_writer.write(MainCameraAdded);
@@ -39,7 +38,7 @@ pub fn add_gizmo_camera(
         &mut Transform,
         (With<MainCamera>, Without<GizmoCamera>, Without<UICamera>),
     >,
-    mut main_camera_added: EventReader<MainCameraAdded>,
+    mut main_camera_added: MessageReader<MainCameraAdded>,
     mut commands: Commands,
 ) {
     for _event in main_camera_added.read() {

--- a/crates/bevy_granite_gizmos/src/gizmos/events.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/events.rs
@@ -1,26 +1,26 @@
-use bevy::prelude::{Entity, Event};
 use super::GizmoType;
+use bevy::prelude::{Entity, Message};
 
-#[derive(Event)]
+#[derive(Message)]
 pub struct RotateInitDragEvent;
 
-#[derive(Event)]
+#[derive(Message)]
 pub struct RotateDraggingEvent;
 
-#[derive(Event)]
+#[derive(Message)]
 pub struct RotateResetDragEvent;
 
-#[derive(Event)]
+#[derive(Message)]
 pub struct TransformInitDragEvent;
 
-#[derive(Event)]
+#[derive(Message)]
 pub struct TransformDraggingEvent;
 
-#[derive(Event)]
+#[derive(Message)]
 pub struct TransformResetDragEvent;
 
-#[derive(Event)]
+#[derive(Message)]
 pub struct SpawnGizmoEvent(pub Entity);
 
-#[derive(Event)]
+#[derive(Message)]
 pub struct DespawnGizmoEvent(pub GizmoType);

--- a/crates/bevy_granite_gizmos/src/gizmos/manager.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/manager.rs
@@ -5,7 +5,7 @@ use super::{
 };
 use crate::{gizmos::NewGizmoType, selection::ActiveSelection};
 use bevy::prelude::{
-    Assets, Children, Commands, Entity, EventReader, EventWriter, GlobalTransform, Mesh, Query,
+    Assets, Children, Commands, Entity, GlobalTransform, Mesh, MessageReader, MessageWriter, Query,
     Res, ResMut, StandardMaterial, With, Without,
 };
 use bevy_granite_logging::{
@@ -20,8 +20,8 @@ pub fn gizmo_events(
     mut transform_query: Query<&GlobalTransform, Without<TransformGizmoParent>>,
     mut rotate_query: Query<&GlobalTransform, Without<RotateGizmoParent>>,
     selected_gizmo: Res<NewGizmoType>,
-    mut spawn_events: EventReader<SpawnGizmoEvent>,
-    mut despawn_events: EventReader<DespawnGizmoEvent>,
+    mut spawn_events: MessageReader<SpawnGizmoEvent>,
+    mut despawn_events: MessageReader<DespawnGizmoEvent>,
     mut transform_gizmo_query: Query<(Entity, &TransformGizmo, &Children)>,
     mut rotate_gizmo_query: Query<(Entity, &RotateGizmo, &Children)>,
     new_config: Res<NewGizmoConfig>,
@@ -60,8 +60,8 @@ pub fn gizmo_events(
 pub fn gizmo_changed_watcher(
     selected_gizmo: Res<NewGizmoType>,
     mut last_selected_gizmo: ResMut<LastSelectedGizmo>,
-    mut despawn_writer: EventWriter<DespawnGizmoEvent>,
-    mut spawn_writer: EventWriter<SpawnGizmoEvent>,
+    mut despawn_writer: MessageWriter<DespawnGizmoEvent>,
+    mut spawn_writer: MessageWriter<SpawnGizmoEvent>,
     active_selection: Query<Entity, With<ActiveSelection>>,
 ) {
     if **selected_gizmo != last_selected_gizmo.value {

--- a/crates/bevy_granite_gizmos/src/gizmos/mod.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/mod.rs
@@ -1,7 +1,7 @@
 use bevy::{
-    ecs::{component::Component, entity::Entity, resource::Resource},
+    camera::visibility::RenderLayers,
+    ecs::{component::Component, entity::Entity, lifecycle::HookContext, resource::Resource},
     prelude::{Deref, DerefMut},
-    render::view::RenderLayers,
 };
 
 pub mod distance_scaling;
@@ -146,10 +146,10 @@ pub struct GizmoOf(pub Entity);
 pub struct GizmoRoot(pub Entity);
 
 impl GizmoOf {
-    fn on_add(mut world: bevy::ecs::world::DeferredWorld, ctx: bevy::ecs::component::HookContext) {
+    fn on_add(mut world: bevy::ecs::world::DeferredWorld, ctx: HookContext) {
         let mut ignore = world
             .get_mut::<EditorIgnore>(ctx.entity)
-            .expect("EditorIgnore is required componet");
+            .expect("EditorIgnore is required component");
         ignore.insert(EditorIgnore::GIZMO | EditorIgnore::PICKING);
     }
 

--- a/crates/bevy_granite_gizmos/src/gizmos/plugin.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/plugin.rs
@@ -1,10 +1,10 @@
 use super::register_embedded_rotate_gizmo_mesh;
 use super::{
-    gizmo_changed_watcher, gizmo_events, handle_init_rotate_drag, 
-    handle_rotate_input, handle_rotate_reset, scale_gizmo_by_camera_distance_system,
-    DespawnGizmoEvent, GizmoSnap, GizmoType, LastSelectedGizmo, NewGizmoConfig,
-    PreviousTransformGizmo, RotateDraggingEvent, RotateInitDragEvent, RotateResetDragEvent,
-    SpawnGizmoEvent, TransformDraggingEvent, TransformInitDragEvent, TransformResetDragEvent,
+    gizmo_changed_watcher, gizmo_events, handle_init_rotate_drag, handle_rotate_input,
+    handle_rotate_reset, scale_gizmo_by_camera_distance_system, DespawnGizmoEvent, GizmoSnap,
+    GizmoType, LastSelectedGizmo, NewGizmoConfig, PreviousTransformGizmo, RotateDraggingEvent,
+    RotateInitDragEvent, RotateResetDragEvent, SpawnGizmoEvent, TransformDraggingEvent,
+    TransformInitDragEvent, TransformResetDragEvent,
 };
 use crate::gizmos::{GizmoMode, NewGizmoType};
 use crate::is_gizmos_active;
@@ -38,14 +38,14 @@ impl Plugin for GizmoPlugin {
             //
             // Events
             //
-            .add_event::<RotateInitDragEvent>()
-            .add_event::<RotateDraggingEvent>()
-            .add_event::<RotateResetDragEvent>()
-            .add_event::<TransformInitDragEvent>()
-            .add_event::<TransformDraggingEvent>()
-            .add_event::<TransformResetDragEvent>()
-            .add_event::<SpawnGizmoEvent>()
-            .add_event::<DespawnGizmoEvent>()
+            .add_message::<RotateInitDragEvent>()
+            .add_message::<RotateDraggingEvent>()
+            .add_message::<RotateResetDragEvent>()
+            .add_message::<TransformInitDragEvent>()
+            .add_message::<TransformDraggingEvent>()
+            .add_message::<TransformResetDragEvent>()
+            .add_message::<SpawnGizmoEvent>()
+            .add_message::<DespawnGizmoEvent>()
             //
             // Schedule system
             //

--- a/crates/bevy_granite_gizmos/src/gizmos/rotate/gizmo.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/rotate/gizmo.rs
@@ -1,14 +1,14 @@
-use bevy::asset::{weak_handle, Handle};
+use bevy::asset::Handle;
 use bevy::ecs::hierarchy::ChildOf;
+use bevy::light::{NotShadowCaster, NotShadowReceiver};
+use bevy::mesh::Mesh3d;
 use bevy::pbr::MeshMaterial3d;
-use bevy::pbr::{NotShadowCaster, NotShadowReceiver};
 use bevy::picking::Pickable;
 use bevy::prelude::{AlphaMode, Meshable, Quat, Sphere};
 use bevy::prelude::{
     Assets, Children, Color, Commands, Component, Entity, GlobalTransform, Mesh, Name, Query,
     ResMut, Resource, StandardMaterial, Transform, Vec3, Visibility, Without,
 };
-use bevy::render::mesh::Mesh3d;
 use bevy_granite_core::TreeHiddenEntity;
 use bevy_granite_logging::{
     config::{LogCategory, LogLevel, LogType},
@@ -32,7 +32,7 @@ pub struct PreviousTransformGizmo {
 const GIZMO_SCALE: f32 = 0.85;
 const ROTATE_INNER_RADIUS: f32 = 0.12 * GIZMO_SCALE; // middle sphere of gizmo (free rotate)
 const ROTATE_VISUAL_RADIUS: f32 = 0.64 * GIZMO_SCALE; // middle sphere of gizmo (visual)
-const RING_MESH_HASH: &str = "3f6f4c2a-6e36-4ccf-81c4-f343f83c5f80"; // constantly random - doesnt matter the value
+const RING_MESH_HASH: uuid::Uuid = uuid::uuid!("3f6f4c2a-6e36-4ccf-81c4-f343f83c5f80"); // constantly random - doesnt matter the value
 
 pub fn register_embedded_rotate_gizmo_mesh(mut meshes: ResMut<Assets<Mesh>>) {
     let handle = get_mesh_handle();
@@ -44,7 +44,7 @@ pub fn register_embedded_rotate_gizmo_mesh(mut meshes: ResMut<Assets<Mesh>>) {
 }
 
 pub fn get_mesh_handle() -> Handle<Mesh> {
-    weak_handle!(RING_MESH_HASH)
+    Handle::Uuid(RING_MESH_HASH, Default::default())
 }
 pub fn spawn_rotate_gizmo(
     parent: Entity,

--- a/crates/bevy_granite_gizmos/src/gizmos/transform/gizmo.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/transform/gizmo.rs
@@ -1,12 +1,13 @@
 use bevy::{
     ecs::hierarchy::{ChildOf, Children},
-    pbr::{MeshMaterial3d, NotShadowCaster, NotShadowReceiver},
+    light::{NotShadowCaster, NotShadowReceiver},
+    mesh::Mesh3d,
+    pbr::MeshMaterial3d,
     prelude::{
         AlphaMode, Assets, Color, Commands, Component, Cone, Cylinder, Entity, GlobalTransform,
         Mesh, Meshable, Name, Quat, Query, ResMut, Resource, Sphere, StandardMaterial, Transform,
         Vec3, Visibility, Without,
     },
-    render::mesh::Mesh3d,
 };
 use bevy_granite_core::TreeHiddenEntity;
 use bevy_granite_logging::{

--- a/crates/bevy_granite_gizmos/src/lib.rs
+++ b/crates/bevy_granite_gizmos/src/lib.rs
@@ -14,12 +14,12 @@ mod ui;
 // Re-export
 pub use camera::GizmoCamera;
 pub use gizmos::{
-    despawn_rotate_gizmo, GizmoChildren, GizmoMesh, GizmoSnap, GizmoType, RotateGizmo,
-    NewGizmoConfig, TransformGizmo,
+    despawn_rotate_gizmo, GizmoChildren, GizmoMesh, GizmoSnap, GizmoType, NewGizmoConfig,
+    RotateGizmo, TransformGizmo,
 };
 pub use input::{watch_gizmo_change, DragState, GizmoAxis};
 pub use selection::{
-    ActiveSelection, EntityEvent, RequestDuplicateAllSelectionEvent, RequestDuplicateEntityEvent,
+    ActiveSelection, EntityEvents, RequestDuplicateAllSelectionEvent, RequestDuplicateEntityEvent,
     Selected,
 };
 
@@ -58,7 +58,7 @@ impl Plugin for BevyGraniteGizmos {
             .add_plugins(SelectionPlugin)
             .add_plugins(UIPlugin)
             .add_plugins(InputPlugin) // Optional
-            .add_event::<MainCameraAdded>()
+            .add_message::<MainCameraAdded>()
             //
             .add_systems(
                 Update,

--- a/crates/bevy_granite_gizmos/src/selection/duplicate.rs
+++ b/crates/bevy_granite_gizmos/src/selection/duplicate.rs
@@ -1,8 +1,5 @@
 use super::{RequestDuplicateAllSelectionEvent, RequestDuplicateEntityEvent};
-use crate::{
-    gizmos::{GizmoChildren},
-    selection::Selected,
-};
+use crate::{gizmos::GizmoChildren, selection::Selected};
 use bevy::{
     asset::Assets,
     ecs::{
@@ -10,10 +7,12 @@ use bevy::{
         query::With,
         system::{Commands, Query},
     },
-    prelude::{AppTypeRegistry, ChildOf, Children, EventReader, ReflectComponent, Res, World},
-    render::mesh::{Mesh, Mesh3d},
+    mesh::{Mesh, Mesh3d},
+    prelude::{AppTypeRegistry, ChildOf, Children, MessageReader, ReflectComponent, Res, World},
 };
-use bevy_granite_core::{entities::GraniteType, EditorIgnore, HasRuntimeData, IconProxy, IdentityData};
+use bevy_granite_core::{
+    entities::GraniteType, EditorIgnore, HasRuntimeData, IconProxy, IdentityData,
+};
 use bevy_granite_logging::{
     config::{LogCategory, LogLevel, LogType},
     log,
@@ -22,7 +21,7 @@ use uuid::Uuid;
 
 pub fn duplicate_entity_system(
     mut commands: Commands,
-    mut duplicate_event_reader: EventReader<RequestDuplicateEntityEvent>,
+    mut duplicate_event_reader: MessageReader<RequestDuplicateEntityEvent>,
     type_registry: Res<AppTypeRegistry>,
 ) {
     for event in duplicate_event_reader.read() {
@@ -49,7 +48,7 @@ pub fn duplicate_entity_system(
 
 pub fn duplicate_all_selection_system(
     mut commands: Commands,
-    mut duplicate_event_reader: EventReader<RequestDuplicateAllSelectionEvent>,
+    mut duplicate_event_reader: MessageReader<RequestDuplicateAllSelectionEvent>,
     type_registry: Res<AppTypeRegistry>,
     selected: Query<Entity, With<Selected>>,
 ) {
@@ -164,8 +163,9 @@ fn collect_entity_info(world: &World, entity: Entity) -> Option<EntityInfo> {
     let component_type_ids: Vec<std::any::TypeId> = entity_ref
         .archetype()
         .components()
+        .iter()
         .filter_map(|component_id| {
-            let component_info = world.components().get_info(component_id)?;
+            let component_info = world.components().get_info(component_id.clone())?;
 
             log!(
                 LogType::Editor,
@@ -344,7 +344,9 @@ fn log_copied_components(world: &World, entity: Entity) {
     let mut component_names = Vec::new();
     if let Ok(entity_ref) = world.get_entity(entity) {
         for archetype_component_id in entity_ref.archetype().components() {
-            if let Some(component_info) = world.components().get_info(archetype_component_id) {
+            if let Some(component_info) =
+                world.components().get_info(archetype_component_id.clone())
+            {
                 component_names.push(component_info.name());
             }
         }

--- a/crates/bevy_granite_gizmos/src/selection/events.rs
+++ b/crates/bevy_granite_gizmos/src/selection/events.rs
@@ -1,7 +1,10 @@
-use bevy::prelude::{Entity, Event};
+use bevy::{
+    ecs::event::Event,
+    prelude::{Entity, Message},
+};
 
 #[derive(Event)]
-pub enum EntityEvent {
+pub enum EntityEvents {
     Select { target: Entity, additive: bool },
     SelectRange { range: Vec<Entity>, additive: bool },
     Deselect { target: Entity },
@@ -9,10 +12,10 @@ pub enum EntityEvent {
     DeselectAll,
 }
 
-#[derive(Event)]
+#[derive(Message)]
 pub struct RequestDuplicateEntityEvent {
     pub entity: Entity,
 }
 
-#[derive(Event)]
+#[derive(Message)]
 pub struct RequestDuplicateAllSelectionEvent;

--- a/crates/bevy_granite_gizmos/src/selection/manager.rs
+++ b/crates/bevy_granite_gizmos/src/selection/manager.rs
@@ -1,6 +1,6 @@
-use crate::selection::{events::EntityEvent, ActiveSelection, Selected};
+use crate::selection::{events::EntityEvents, ActiveSelection, Selected};
 use bevy::{
-    ecs::{observer::Trigger, world::OnAdd},
+    ecs::{lifecycle::Add, observer::On},
     prelude::{Component, Entity, Query, Res, With},
 };
 use bevy::{
@@ -36,14 +36,14 @@ pub struct ParentTo(pub Entity);
 
 // this is incharge of setting entities into the selected state
 pub fn select_entity(
-    event: Trigger<EntityEvent>,
+    event: On<EntityEvents>,
     mut commands: Commands,
     current: Query<Entity, With<Selected>>,
     active_selection: Query<(), With<ActiveSelection>>,
 ) {
     let (first, add, others) = match event.event() {
-        EntityEvent::Select { target, additive } => (*target, *additive, None),
-        EntityEvent::SelectRange { range, additive } => {
+        EntityEvents::Select { target, additive } => (*target, *additive, None),
+        EntityEvents::SelectRange { range, additive } => {
             let Some(first) = range.first() else {
                 log! {
                     LogType::Editor,
@@ -83,22 +83,28 @@ pub fn select_entity(
 
 // Used when we get a single entity deselected
 pub fn deselect_entity(
-    event: Trigger<EntityEvent>,
+    event: On<EntityEvents>,
     mut commands: Commands,
     selection: Query<Entity, With<Selected>>,
 ) {
     match event.event() {
-        EntityEvent::Deselect { target } => {
-            commands.entity(*target).remove::<(ActiveSelection, Selected)>();
+        EntityEvents::Deselect { target } => {
+            commands
+                .entity(*target)
+                .remove::<(ActiveSelection, Selected)>();
         }
-        EntityEvent::DeselectRange { range } => {
+        EntityEvents::DeselectRange { range } => {
             for entity in range {
-                commands.entity(*entity).remove::<(ActiveSelection, Selected)>();
+                commands
+                    .entity(*entity)
+                    .remove::<(ActiveSelection, Selected)>();
             }
         }
-        EntityEvent::DeselectAll => {
+        EntityEvents::DeselectAll => {
             for entity in selection.iter() {
-                commands.entity(entity).remove::<(ActiveSelection, Selected)>();
+                commands
+                    .entity(entity)
+                    .remove::<(ActiveSelection, Selected)>();
             }
         }
         _ => {}
@@ -108,14 +114,13 @@ pub fn deselect_entity(
 /// when an entity gets ActiveSelection added to it we check if there is already an entity with ActiveSelection
 /// if there is, we remove it for the other entity
 pub fn single_active(
-    mut add_active: Trigger<OnAdd, ActiveSelection>,
+    add_active: On<Add, ActiveSelection>,
     active_selection: Query<Entity, With<ActiveSelection>>,
     mut commands: Commands,
 ) {
-    add_active.propagate(false);
     if active_selection.single().is_err() {
         for entity in &active_selection {
-            if entity != add_active.target() {
+            if entity != add_active.entity {
                 commands.entity(entity).remove::<ActiveSelection>();
             }
         }
@@ -123,7 +128,7 @@ pub fn single_active(
 }
 
 pub fn handle_picking_selection(
-    mut on_click: Trigger<Pointer<Click>>,
+    mut on_click: On<Pointer<Click>>,
     mut commands: Commands,
     ignored: Query<&EditorIgnore>,
     icon_proxy_query: Query<&IconProxy>,
@@ -132,14 +137,14 @@ pub fn handle_picking_selection(
     if on_click.button != bevy::picking::pointer::PointerButton::Primary {
         return;
     }
-    match ignored.get(on_click.target()) {
+    match ignored.get(on_click.entity) {
         Ok(to_ignore) => {
             if to_ignore.contains(EditorIgnore::PICKING) {
                 return;
             }
         }
         Err(QueryEntityError::EntityDoesNotExist(_)) => {
-            log!("Entity does not exist: {}", on_click.target().index());
+            log!("Entity does not exist: {}", on_click.entity.index());
             return;
         }
         Err(_) => {}
@@ -147,8 +152,8 @@ pub fn handle_picking_selection(
     if user_input.mouse_over_egui {
         return;
     }
-    
-    if on_click.target().index() == 0 {
+
+    if on_click.entity.index() == 0 {
         log!(
             LogType::Editor,
             LogLevel::Info,
@@ -156,12 +161,12 @@ pub fn handle_picking_selection(
             "Clicked on empty space, deselecting all entities"
         );
         on_click.propagate(false);
-        commands.trigger(EntityEvent::DeselectAll);
+        commands.trigger(EntityEvents::DeselectAll);
         return;
     }
-    
+
     on_click.propagate(false);
-    let mut entity = on_click.target();
+    let mut entity = on_click.entity;
 
     // redirect to icon target
     if let Ok(icon_proxy) = icon_proxy_query.get(entity) {
@@ -175,7 +180,7 @@ pub fn handle_picking_selection(
         entity = icon_proxy.target_entity;
     }
 
-    commands.trigger(EntityEvent::Select {
+    commands.trigger(EntityEvents::Select {
         target: entity,
         additive: user_input.shift_left.any,
     });

--- a/crates/bevy_granite_gizmos/src/selection/mod.rs
+++ b/crates/bevy_granite_gizmos/src/selection/mod.rs
@@ -1,7 +1,5 @@
 use bevy::ecs::{
-    component::{Component, HookContext},
-    event::Events,
-    world::DeferredWorld,
+    component::Component, lifecycle::HookContext, message::Messages, world::DeferredWorld,
 };
 
 pub mod duplicate;
@@ -18,9 +16,7 @@ pub struct ActiveSelection;
 
 impl ActiveSelection {
     fn on_add(mut world: DeferredWorld, ctx: HookContext) {
-        world
-            .resource_mut::<Events<SpawnGizmoEvent>>()
-            .send(SpawnGizmoEvent(ctx.entity));
+        world.write_message(SpawnGizmoEvent(ctx.entity));
     }
     fn on_remove(mut world: DeferredWorld, ctx: HookContext) {
         if let Ok(_entity_commands) = world.commands().get_entity(ctx.entity) {
@@ -43,7 +39,7 @@ impl ActiveSelection {
 pub struct Selected;
 
 pub use duplicate::{duplicate_all_selection_system, duplicate_entity_system};
-pub use events::{EntityEvent, RequestDuplicateAllSelectionEvent, RequestDuplicateEntityEvent};
+pub use events::{EntityEvents, RequestDuplicateAllSelectionEvent, RequestDuplicateEntityEvent};
 pub use manager::{apply_pending_parents, handle_picking_selection, select_entity};
 pub use plugin::SelectionPlugin;
 pub use ray::{RaycastCursorLast, RaycastCursorPos};

--- a/crates/bevy_granite_gizmos/src/selection/plugin.rs
+++ b/crates/bevy_granite_gizmos/src/selection/plugin.rs
@@ -17,8 +17,8 @@ impl Plugin for SelectionPlugin {
             //
             // Events
             //
-            .add_event::<RequestDuplicateEntityEvent>()
-            .add_event::<RequestDuplicateAllSelectionEvent>()
+            .add_message::<RequestDuplicateEntityEvent>()
+            .add_message::<RequestDuplicateAllSelectionEvent>()
             //
             // Resources
             //

--- a/examples/dungeon.rs
+++ b/examples/dungeon.rs
@@ -36,7 +36,7 @@ fn main() {
         .run();
 }
 
-fn setup(mut open_event: EventWriter<RequestLoadEvent>) {
+fn setup(mut open_event: MessageWriter<RequestLoadEvent>) {
     open_event.write(RequestLoadEvent(
         STARTING_WORLD.to_string(),
         SaveSettings::Runtime,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,18 +141,16 @@ pub mod prelude {
         bevy_granite_core::{
             absolute_asset_to_rel, rel_asset_to_absolute, BridgeTag, MainCamera,
             RequestDespawnBySource, RequestDespawnSerializableEntities, RequestLoadEvent,
-            RequestReloadEvent, RequestSaveEvent, SaveSettings, SpawnSource, TreeHiddenEntity, UICamera,
-            WorldLoadSuccessEvent, WorldSaveSuccessEvent,
+            RequestReloadEvent, RequestSaveEvent, SaveSettings, SpawnSource, TreeHiddenEntity,
+            UICamera, WorldLoadSuccessEvent, WorldSaveSuccessEvent,
         },
         bevy_granite_logging::{log, LogCategory, LogLevel, LogType},
         bevy_granite_macros::{granite_component, register_editor_components, ui_callable_events},
     };
 
-
-
     #[cfg(feature = "gizmos")]
     pub use crate::bevy_granite_gizmos::{
-        EntityEvent, RequestDuplicateAllSelectionEvent, RequestDuplicateEntityEvent,
+        EntityEvents, RequestDuplicateAllSelectionEvent, RequestDuplicateEntityEvent,
     };
 
     #[cfg(feature = "editor")]


### PR DESCRIPTION
This was hell all because of one change Bevy made that took me forever to work out.
Apprently you need RenderLayers::from_layes(&[0,14]) but is 0.16 we used RenderLayers::layer(14)
This made nothing other than egui render after the ui camera spawned.

I spent so long trying to fix this, I ended up basically implementing a fix for the viewport not being the camera centre. So I finished that even after I worked out the easy fix. We now have a UI camera with a Viewport camera as its child; this could cause issues with used generated cameras since they won't have their Viewport field set correctly.
