### PR TITLE
feat(camera): Add dedicated editor camera

### DIFF
--- a/crates/bevy_granite_editor/src/interface/events.rs
+++ b/crates/bevy_granite_editor/src/interface/events.rs
@@ -18,6 +18,7 @@ pub struct EditorEvents<'w> {
     pub load: EventWriter<'w, RequestLoadEvent>,
     pub toggle_editor: EventWriter<'w, RequestEditorToggle>,
     pub toggle_cam_sync: EventWriter<'w, RequestToggleCameraSync>,
+    pub viewport_camera: EventWriter<'w, RequestViewportCameraOverride>,
     pub frame: EventWriter<'w, RequestCameraEntityFrame>,
     pub parent: EventWriter<'w, RequestNewParent>,
     pub remove_parent: EventWriter<'w, RequestRemoveParents>,
@@ -89,6 +90,11 @@ pub struct RequestCameraEntityFrame;
 
 #[derive(Event)]
 pub struct RequestToggleCameraSync;
+
+#[derive(Event)]
+pub struct RequestViewportCameraOverride {
+    pub camera: Option<Entity>,
+}
 
 #[derive(Event)]
 pub struct RequestNewParent;

--- a/crates/bevy_granite_editor/src/interface/plugin.rs
+++ b/crates/bevy_granite_editor/src/interface/plugin.rs
@@ -3,7 +3,7 @@ use super::{
     events::{
         MaterialDeleteEvent, MaterialHandleUpdateEvent, PopupMenuRequestedEvent,
         RequestCameraEntityFrame, RequestEditorToggle, RequestNewParent, RequestRemoveChildren,
-        RequestRemoveParents, RequestToggleCameraSync, SetActiveWorld,
+        RequestRemoveParents, RequestToggleCameraSync, RequestViewportCameraOverride, SetActiveWorld,
         UserRequestGraniteTypeViaPopup, UserUpdatedComponentsEvent, UserUpdatedIdentityEvent,
         UserUpdatedTransformEvent,
     },
@@ -43,6 +43,7 @@ impl Plugin for InterfacePlugin {
             .add_event::<RequestEditorToggle>()
             .add_event::<RequestCameraEntityFrame>()
             .add_event::<RequestToggleCameraSync>()
+            .add_event::<RequestViewportCameraOverride>()
             .add_event::<RequestNewParent>()
             .add_event::<RequestRemoveChildren>()
             .add_event::<RequestRemoveParents>()
@@ -105,3 +106,4 @@ impl Plugin for InterfacePlugin {
             .add_systems(Update, send_queued_events_system.run_if(is_editor_active));
     }
 }
+

--- a/crates/bevy_granite_editor/src/viewport/camera/components.rs
+++ b/crates/bevy_granite_editor/src/viewport/camera/components.rs
@@ -1,0 +1,44 @@
+use bevy::prelude::{Component, Entity, Resource, Transform};
+
+/// Marker component for the editor's dedicated 3D viewport camera.
+#[derive(Component)]
+pub struct EditorViewportCamera;
+
+/// Tracks which camera should currently be rendered in the editor viewport.
+#[derive(Resource, Default)]
+pub struct ViewportCameraState {
+    pub editor_camera: Option<Entity>,
+    pub active_override: Option<Entity>,
+    pub stored_editor_transform: Option<Transform>,
+}
+
+impl ViewportCameraState {
+    pub fn active_camera(&self) -> Option<Entity> {
+        self.active_override.or(self.editor_camera)
+    }
+
+    pub fn is_using_editor(&self) -> bool {
+        self.active_override.is_none()
+    }
+
+    pub fn set_editor_camera(&mut self, entity: Entity) {
+        self.editor_camera = Some(entity);
+    }
+
+    pub fn set_override(&mut self, entity: Entity) {
+        self.active_override = Some(entity);
+    }
+
+    pub fn clear_override(&mut self) {
+        self.active_override = None;
+    }
+
+    pub fn store_editor_transform(&mut self, transform: Transform) {
+        self.stored_editor_transform = Some(transform);
+    }
+
+    pub fn take_stored_editor_transform(&mut self) -> Option<Transform> {
+        self.stored_editor_transform.take()
+    }
+}
+

--- a/crates/bevy_granite_editor/src/viewport/camera/mod.rs
+++ b/crates/bevy_granite_editor/src/viewport/camera/mod.rs
@@ -1,5 +1,7 @@
+pub mod components;
 pub mod system;
 pub mod utils;
 
+pub use components::*;
 pub use system::*;
 pub use utils::*;

--- a/crates/bevy_granite_editor/src/viewport/mod.rs
+++ b/crates/bevy_granite_editor/src/viewport/mod.rs
@@ -7,8 +7,18 @@ pub mod plugin;
 pub mod state;
 
 pub use camera::{
-    add_ui_camera, camera_frame_system, camera_sync_toggle_system, mouse_button_iter,
-    sync_cameras_system, CameraSyncState, CameraTarget, InputState,
+    add_editor_camera,
+    add_ui_camera,
+    camera_frame_system,
+    camera_sync_toggle_system,
+    enforce_viewport_camera_state,
+    mouse_button_iter,
+    sync_cameras_system,
+    CameraSyncState,
+    CameraTarget,
+    EditorViewportCamera,
+    InputState,
+    ViewportCameraState,
 };
 pub use state::ViewportState;
 


### PR DESCRIPTION
## Summary
- Add a persistent editor viewport camera and track active overrides so editor view no longer depends on scene `MainCamera` entities
- Expose scene camera takeover in the top bar, restore runtime cameras when exiting editor mode, and keep gizmo visuals consistent across all scene cameras

## Motivation
- Editor previously required a scene `MainCamera`, leading to duplicated rendering, grid artifacts, and confusion when multiple cameras existed. A dedicated editor camera ensures the viewport always works, regardless of scene content.
- Designers need to preview through game cameras but should explicitly opt in and revert. UI controls and runtime restoration give them that flexibility without breaking gameplay or leaving stray active cameras.

## Details
- Introduced `EditorViewportCamera` marker and `ViewportCameraState` resource (`camera/components.rs`), spawned the editor camera at startup, and adjusted camera systems to sync transforms, deactivate scene cameras unless deliberately overridden, and store/restore editor transforms (`camera/utils.rs`, `camera/system.rs`, `viewport/plugin.rs`, `viewport/mod.rs`).
- Added `RequestViewportCameraOverride` event, integrated it through interface plumbing (`interface/events.rs`, `interface/plugin.rs`, `lib.rs`), and collected eligible cameras in the dock layout so the top bar can list them with friendly labels (`interface/layout/dock.rs`, `interface/layout/top_bar.rs`).
- UI now shows the current viewing camera, offers menu entries to switch to scene cameras or back to the editor camera, and resyncs state when scenes change or cameras despawn.
- When editor mode is inactive, `restore_runtime_camera_state` re-enables `MainCamera` entities (or all window cameras as a fallback), clears overrides, and ensures the editor camera doesn’t remain active.
- Gizmo debug system now targets any scene `Camera3d` that isn’t an editor or UI camera, so direction gizmos appear consistently (`viewport/debug/cameras.rs`).
