### PR TITLE
refactor(viewport): refactor cameras/layers/grid

### DIFF
--- a/crates/bevy_granite_editor/src/interface/layout/dock.rs
+++ b/crates/bevy_granite_editor/src/interface/layout/dock.rs
@@ -14,13 +14,12 @@ use crate::{
 
 use bevy::{
     camera::{Camera, Camera3d, RenderTarget},
-    ecs::{
-        system::{Commands, Query},
-    },
+    ecs::system::{Commands, Query},
     prelude::{Entity, Name, Res, ResMut},
 };
 use bevy_egui::{egui, EguiContexts};
 use bevy_granite_core::{UICamera, UserInput};
+use bevy_granite_gizmos::GizmoCamera;
 use egui_dock::DockArea;
 use serde::{Deserialize, Serialize};
 
@@ -58,23 +57,36 @@ pub fn dock_ui_system(
     editor_state: Res<EditorState>,
     user_input: Res<UserInput>,
     mut commands: Commands,
-    mut camera_query: Query<
-        (Entity, Option<&Name>, &mut Camera, Option<&Camera3d>, Option<&UICamera>, Option<&EditorViewportCamera>, Option<&crate::ViewPortCamera>)
-    >,
+    camera_query: Query<(
+        Entity,
+        Option<&Name>,
+        &Camera,
+        Option<&Camera3d>,
+        Option<&EditorViewportCamera>,
+        Option<&UICamera>,
+        Option<&GizmoCamera>,
+    )>,
     viewport_camera_state: Res<ViewportCameraState>,
 ) {
     let mut camera_options: Vec<(Entity, String)> = camera_query
-        .iter_mut()
-        .filter_map(|(entity, name, camera, camera3d, uicamera, editorviewportcamera, _)| {
-            if camera3d.is_some() && uicamera.is_none() && editorviewportcamera.is_none() && matches!(camera.target, RenderTarget::Window(_)) {
-                let label = name
-                    .map(|n| n.as_str().to_string())
-                    .unwrap_or_else(|| format!("Camera {}", entity.index()));
-                Some((entity, label))
-            } else {
-                None
-            }
-        })
+        .iter()
+        .filter_map(
+            |(entity, name, camera, camera3d, editor_camera, ui_camera, gizmo_camera)| {
+                if camera3d.is_some()
+                    && editor_camera.is_none()
+                    && ui_camera.is_none()
+                    && gizmo_camera.is_none()
+                    && matches!(camera.target, RenderTarget::Window(_))
+                {
+                    let label = name
+                        .map(|n| n.as_str().to_string())
+                        .unwrap_or_else(|| format!("Camera {}", entity.index()));
+                    Some((entity, label))
+                } else {
+                    None
+                }
+            },
+        )
         .collect();
     camera_options.sort_by(|a, b| a.1.cmp(&b.1));
 
@@ -87,7 +99,6 @@ pub fn dock_ui_system(
     let bottom_panel_height = (screen_height * 0.05).clamp(100., 400.);
 
     let space = get_interface_config_float("ui.spacing");
-    let mut left = false;
     egui::TopBottomPanel::top("tool_panel")
         .resizable(false)
         .show(ctx, |ui| {
@@ -109,7 +120,6 @@ pub fn dock_ui_system(
     let side_panel_position = editor_state.config.dock.side_panel_position;
     match side_panel_position {
         SidePanelPosition::Left => {
-            left = true;
             egui::SidePanel::left("left_dock_panel")
                 .resizable(true)
                 .default_width(right_panel_width)
@@ -143,22 +153,4 @@ pub fn dock_ui_system(
                 .id(egui::Id::new("bottom_dock_area"))
                 .show_inside(ui, &mut BottomTabViewer);
         });
-
-    let size = ctx.available_rect();
-    for (_, _, mut camera, _, _, _, viewportcamera) in camera_query.iter_mut() {
-        if viewportcamera.is_some() {
-            let width = (size.width() * 1.5) as u32;
-            let height = (size.height() * 1.5) as u32;
-            let Some(viewport) = camera.viewport.as_mut() else {
-                continue;
-            };
-            if left {
-                viewport.physical_position.x = screen_width as u32 - width;
-            } else {
-                viewport.physical_position.x = 0;
-            }
-            viewport.physical_position.y = (size.min.y * 1.5) as u32;
-            viewport.physical_size = bevy::prelude::UVec2::new(width, height);
-        }
-    }
 }

--- a/crates/bevy_granite_editor/src/interface/plugin.rs
+++ b/crates/bevy_granite_editor/src/interface/plugin.rs
@@ -3,9 +3,9 @@ use super::{
     events::{
         MaterialDeleteEvent, MaterialHandleUpdateEvent, PopupMenuRequestedEvent,
         RequestCameraEntityFrame, RequestEditorToggle, RequestNewParent, RequestRemoveChildren,
-        RequestRemoveParents, RequestToggleCameraSync, RequestViewportCameraOverride, SetActiveWorld,
-        UserRequestGraniteTypeViaPopup, UserUpdatedComponentsEvent, UserUpdatedIdentityEvent,
-        UserUpdatedTransformEvent,
+        RequestRemoveParents, RequestToggleCameraSync, RequestViewportCameraOverride,
+        SetActiveWorld, UserRequestGraniteTypeViaPopup, UserUpdatedComponentsEvent,
+        UserUpdatedIdentityEvent, UserUpdatedTransformEvent,
     },
     layout::dock_ui_system,
     popups::{handle_popup_requests_system, show_active_popups_system},
@@ -47,8 +47,7 @@ impl Plugin for InterfacePlugin {
             .add_message::<RequestRemoveChildren>()
             .add_message::<RequestRemoveParents>()
             .add_message::<SetActiveWorld>()
-            .add_event::<RequestViewportCameraOverride>() // from #78
-
+            .add_message::<RequestViewportCameraOverride>()
             // need to rework
             .add_message::<RequestReparentEntityEvent>()
             .add_message::<RequestRemoveParentsFromEntities>()
@@ -107,4 +106,3 @@ impl Plugin for InterfacePlugin {
             .add_systems(Update, send_queued_events_system.run_if(is_editor_active));
     }
 }
-

--- a/crates/bevy_granite_editor/src/viewport/camera/components.rs
+++ b/crates/bevy_granite_editor/src/viewport/camera/components.rs
@@ -1,3 +1,4 @@
+use bevy::camera::visibility::RenderLayers;
 use bevy::prelude::{Component, Entity, Resource, Transform};
 
 /// Marker component for the editor's dedicated 3D viewport camera.
@@ -10,6 +11,7 @@ pub struct ViewportCameraState {
     pub editor_camera: Option<Entity>,
     pub active_override: Option<Entity>,
     pub stored_editor_transform: Option<Transform>,
+    pub override_render_state: Option<(Entity, Option<RenderLayers>)>,
 }
 
 impl ViewportCameraState {
@@ -40,5 +42,18 @@ impl ViewportCameraState {
     pub fn take_stored_editor_transform(&mut self) -> Option<Transform> {
         self.stored_editor_transform.take()
     }
-}
 
+    pub fn store_override_render_layers(&mut self, entity: Entity, layers: Option<RenderLayers>) {
+        self.override_render_state = Some((entity, layers));
+    }
+
+    pub fn take_override_render_layers(&mut self) -> Option<(Entity, Option<RenderLayers>)> {
+        self.override_render_state.take()
+    }
+
+    pub fn override_layers_entity(&self) -> Option<Entity> {
+        self.override_render_state
+            .as_ref()
+            .map(|(entity, _)| *entity)
+    }
+}

--- a/crates/bevy_granite_editor/src/viewport/camera/constants.rs
+++ b/crates/bevy_granite_editor/src/viewport/camera/constants.rs
@@ -1,0 +1,22 @@
+use bevy::camera::visibility::RenderLayers;
+
+pub const LAYER_SCENE: usize = 0;
+pub const LAYER_GRID: usize = 13;
+pub const LAYER_GIZMO: usize = 14;
+pub const LAYER_UI: usize = 31;
+
+pub fn scene_layers() -> RenderLayers {
+    RenderLayers::from_layers(&[LAYER_SCENE, LAYER_GRID])
+}
+
+pub fn grid_layers() -> RenderLayers {
+    RenderLayers::layer(LAYER_GRID)
+}
+
+pub fn gizmo_layers() -> RenderLayers {
+    RenderLayers::layer(LAYER_GIZMO)
+}
+
+pub fn ui_layers() -> RenderLayers {
+    RenderLayers::layer(LAYER_UI)
+}

--- a/crates/bevy_granite_editor/src/viewport/camera/mod.rs
+++ b/crates/bevy_granite_editor/src/viewport/camera/mod.rs
@@ -1,7 +1,9 @@
 pub mod components;
+pub mod constants;
 pub mod system;
 pub mod utils;
 
 pub use components::*;
+pub use constants::*;
 pub use system::*;
 pub use utils::*;

--- a/crates/bevy_granite_editor/src/viewport/camera/system.rs
+++ b/crates/bevy_granite_editor/src/viewport/camera/system.rs
@@ -1,17 +1,32 @@
 use crate::{
-    editor_state::INPUT_CONFIG,
+    editor_state::{EditorState, INPUT_CONFIG},
     entities::bounds::get_entity_bounds_world,
-    interface::events::{RequestCameraEntityFrame, RequestToggleCameraSync, RequestViewportCameraOverride},
-    viewport::camera::{handle_movement, handle_zoom, rotate_camera_towards, ViewportCameraState},
+    interface::events::{
+        RequestCameraEntityFrame, RequestToggleCameraSync, RequestViewportCameraOverride,
+    },
+    viewport::camera::{
+        handle_movement, handle_zoom, rotate_camera_towards, ViewportCameraState, LAYER_GIZMO,
+        LAYER_GRID, LAYER_SCENE,
+    },
 };
 use bevy::{
-    asset::Assets, camera::{Camera, Camera3d, RenderTarget}, ecs::entity::Entity, input::mouse::{MouseMotion, MouseWheel}, mesh::{Mesh, Mesh3d}, prelude::{
-        Local, MessageReader, Query, Res, ResMut, Resource, Time, Transform, Vec2, Vec3, Window,
-        With, Without,
-    }, transform::components::GlobalTransform, window::{CursorGrabMode, CursorOptions, PrimaryWindow}
+    asset::Assets,
+    camera::{visibility::RenderLayers, Camera, Camera3d, RenderTarget, Viewport},
+    ecs::{entity::Entity, system::Commands},
+    input::mouse::{MouseMotion, MouseWheel},
+    mesh::{Mesh, Mesh3d},
+    prelude::{
+        Local, MessageReader, Query, Res, ResMut, Resource, Time, Transform, UVec2, Vec2, Vec3,
+        Window, With, Without,
+    },
+    transform::components::GlobalTransform,
+    window::{CursorGrabMode, CursorOptions, PrimaryWindow},
 };
+use bevy_egui::EguiContexts;
 use bevy_granite_core::{MainCamera, UICamera, UserInput};
-use bevy_granite_gizmos::{ActiveSelection, DragState, Selected};
+use bevy_granite_gizmos::{
+    ActiveSelection, DragState, GizmoCamera, GizmoVisibilityState, Selected,
+};
 use bevy_granite_logging::{log, LogCategory, LogLevel, LogType};
 
 #[derive(Resource, Default)]
@@ -39,9 +54,36 @@ impl Default for CameraSyncState {
     }
 }
 
+fn compute_viewport_layers(existing: Option<&RenderLayers>) -> RenderLayers {
+    let mut layers = vec![LAYER_SCENE, LAYER_GRID];
+    if let Some(existing_layers) = existing {
+        for layer in existing_layers.iter() {
+            if layer == LAYER_GIZMO {
+                continue;
+            }
+            if !layers.contains(&layer) {
+                layers.push(layer);
+            }
+        }
+    }
+    RenderLayers::from_layers(&layers)
+}
+
+fn restore_render_layers(commands: &mut Commands, entity: Entity, layers: Option<RenderLayers>) {
+    if let Some(layers) = layers {
+        commands.entity(entity).insert(layers);
+    } else {
+        commands.entity(entity).remove::<RenderLayers>();
+    }
+}
+
 pub fn sync_cameras_system(
+    mut commands: Commands,
     mut ui_camera_query: Query<&mut Transform, With<UICamera>>,
-    mut active_camera_query: Query<&mut Transform, (With<Camera3d>, Without<UICamera>)>,
+    mut active_camera_query: Query<
+        &mut Transform,
+        (With<Camera3d>, Without<UICamera>, Without<GizmoCamera>),
+    >,
     mut camera_state: ResMut<CameraSyncState>,
     mut viewport_camera_state: ResMut<ViewportCameraState>,
 ) {
@@ -57,13 +99,20 @@ pub fn sync_cameras_system(
         Ok(transform) => transform,
         Err(_) => {
             if viewport_camera_state.active_override.is_some() {
+                if let Some((stored_entity, stored_layers)) =
+                    viewport_camera_state.take_override_render_layers()
+                {
+                    restore_render_layers(&mut commands, stored_entity, stored_layers);
+                }
                 viewport_camera_state.clear_override();
-                if let Some(stored_transform) = viewport_camera_state.take_stored_editor_transform() {
+                if let Some(stored_transform) = viewport_camera_state.take_stored_editor_transform()
+                {
                     ui_camera_transform.translation = stored_transform.translation;
                     ui_camera_transform.rotation = stored_transform.rotation;
 
                     if let Some(editor_entity) = viewport_camera_state.editor_camera {
-                        if let Ok(mut editor_transform) = active_camera_query.get_mut(editor_entity) {
+                        if let Ok(mut editor_transform) = active_camera_query.get_mut(editor_entity)
+                        {
                             *editor_transform = stored_transform;
                         }
                     }
@@ -113,7 +162,10 @@ pub fn camera_sync_toggle_system(
 
 pub fn enforce_viewport_camera_state(
     viewport_camera_state: Res<ViewportCameraState>,
-    mut camera_query: Query<(Entity, &mut Camera), (With<Camera3d>, Without<UICamera>)>,
+    mut camera_query: Query<
+        (Entity, &mut Camera),
+        (With<Camera3d>, Without<UICamera>, Without<GizmoCamera>),
+    >,
 ) {
     let Some(active_camera_entity) = viewport_camera_state.active_camera() else {
         return;
@@ -136,20 +188,38 @@ pub fn enforce_viewport_camera_state(
 }
 
 pub fn restore_runtime_camera_state(
+    mut commands: Commands,
     mut viewport_camera_state: ResMut<ViewportCameraState>,
     mut ui_camera_query: Query<&mut Transform, With<UICamera>>,
-    mut camera_transform_query: Query<&mut Transform, (With<Camera3d>, Without<UICamera>)>,
-    mut camera_query: Query<(Entity, &mut Camera), (With<Camera3d>, Without<UICamera>)>,
+    mut camera_transform_query: Query<
+        &mut Transform,
+        (With<Camera3d>, Without<UICamera>, Without<GizmoCamera>),
+    >,
+    mut camera_query: Query<
+        (Entity, &mut Camera),
+        (With<Camera3d>, Without<UICamera>, Without<GizmoCamera>),
+    >,
     main_camera_entities: Query<Entity, With<MainCamera>>,
 ) {
-    if viewport_camera_state.active_override.is_some() {
+    if let Some(active_override) = viewport_camera_state.active_override {
+        if let Some((stored_entity, stored_layers)) =
+            viewport_camera_state.take_override_render_layers()
+        {
+            if stored_entity == active_override {
+                restore_render_layers(&mut commands, stored_entity, stored_layers);
+            } else {
+                viewport_camera_state.store_override_render_layers(stored_entity, stored_layers);
+            }
+        }
+
         if let Ok(mut ui_transform) = ui_camera_query.single_mut() {
             if let Some(stored_transform) = viewport_camera_state.take_stored_editor_transform() {
                 ui_transform.translation = stored_transform.translation;
                 ui_transform.rotation = stored_transform.rotation;
 
                 if let Some(editor_entity) = viewport_camera_state.editor_camera {
-                    if let Ok(mut editor_transform) = camera_transform_query.get_mut(editor_entity) {
+                    if let Ok(mut editor_transform) = camera_transform_query.get_mut(editor_entity)
+                    {
                         *editor_transform = stored_transform;
                     }
                 }
@@ -172,7 +242,8 @@ pub fn restore_runtime_camera_state(
 
     if any_main_enabled {
         for (entity, mut camera) in camera_query.iter_mut() {
-            if !main_entities.contains(&entity) && matches!(camera.target, RenderTarget::Window(_)) {
+            if !main_entities.contains(&entity) && matches!(camera.target, RenderTarget::Window(_))
+            {
                 camera.is_active = false;
             }
         }
@@ -183,15 +254,30 @@ pub fn restore_runtime_camera_state(
             }
         }
     }
+
+    // Clear ALL custom viewports when exiting editor
+    for (_, mut camera) in camera_query.iter_mut() {
+        if matches!(camera.target, RenderTarget::Window(_)) {
+            camera.viewport = None;
+        }
+    }
 }
 
 pub fn handle_viewport_camera_override_requests(
     mut requests: MessageReader<RequestViewportCameraOverride>,
     mut viewport_camera_state: ResMut<ViewportCameraState>,
     mut camera_sync_state: ResMut<CameraSyncState>,
+    mut commands: Commands,
     mut ui_camera_query: Query<&mut Transform, With<UICamera>>,
-    mut camera_transform_query: Query<&mut Transform, (With<Camera3d>, Without<UICamera>)>,
-    camera_meta_query: Query<&Camera, (With<Camera3d>, Without<UICamera>)>,
+    mut camera_transform_query: Query<
+        &mut Transform,
+        (With<Camera3d>, Without<UICamera>, Without<GizmoCamera>),
+    >,
+    camera_meta_query: Query<&Camera, (With<Camera3d>, Without<UICamera>, Without<GizmoCamera>)>,
+    render_layers_query: Query<
+        &RenderLayers,
+        (With<Camera3d>, Without<UICamera>, Without<GizmoCamera>),
+    >,
 ) {
     for RequestViewportCameraOverride { camera } in requests.read() {
         let Ok(mut ui_transform) = ui_camera_query.single_mut() else {
@@ -201,6 +287,21 @@ pub fn handle_viewport_camera_override_requests(
         if let Some(target_entity) = camera {
             if Some(*target_entity) == viewport_camera_state.active_override {
                 continue;
+            }
+
+            if let Some(current_override) = viewport_camera_state.active_override {
+                if current_override != *target_entity {
+                    if let Some((stored_entity, stored_layers)) =
+                        viewport_camera_state.take_override_render_layers()
+                    {
+                        if stored_entity == current_override {
+                            restore_render_layers(&mut commands, stored_entity, stored_layers);
+                        } else {
+                            viewport_camera_state
+                                .store_override_render_layers(stored_entity, stored_layers);
+                        }
+                    }
+                }
             }
 
             let Ok(target_camera) = camera_meta_query.get(*target_entity) else {
@@ -250,11 +351,31 @@ pub fn handle_viewport_camera_override_requests(
                 }
             }
 
+            let existing_layers = render_layers_query.get(*target_entity).ok().cloned();
+            let new_layers = compute_viewport_layers(existing_layers.as_ref());
+            viewport_camera_state.store_override_render_layers(*target_entity, existing_layers);
+            commands.entity(*target_entity).insert(new_layers);
+
             viewport_camera_state.set_override(*target_entity);
             camera_sync_state.ui_camera_old_position = None;
         } else {
             if viewport_camera_state.active_override.is_none() {
                 continue;
+            }
+
+            if let Some((stored_entity, stored_layers)) =
+                viewport_camera_state.take_override_render_layers()
+            {
+                if let Some(active_override) = viewport_camera_state.active_override {
+                    if stored_entity == active_override {
+                        restore_render_layers(&mut commands, stored_entity, stored_layers);
+                    } else {
+                        viewport_camera_state
+                            .store_override_render_layers(stored_entity, stored_layers);
+                    }
+                } else {
+                    restore_render_layers(&mut commands, stored_entity, stored_layers);
+                }
             }
 
             viewport_camera_state.clear_override();
@@ -265,12 +386,131 @@ pub fn handle_viewport_camera_override_requests(
                 ui_transform.rotation = stored_transform.rotation;
 
                 if let Some(editor_entity) = viewport_camera_state.editor_camera {
-                    if let Ok(mut editor_transform) = camera_transform_query.get_mut(editor_entity) {
+                    if let Ok(mut editor_transform) = camera_transform_query.get_mut(editor_entity)
+                    {
                         *editor_transform = stored_transform;
                     }
                 }
             }
         }
+    }
+}
+
+pub fn update_viewport_camera_viewports_system(
+    mut contexts: EguiContexts,
+    editor_state: Res<EditorState>,
+    viewport_camera_state: Res<ViewportCameraState>,
+    mut camera_query: Query<&mut Camera, (With<Camera3d>, Without<UICamera>, Without<GizmoCamera>)>,
+    mut gizmo_camera_query: Query<&mut Camera, With<GizmoCamera>>,
+    primary_window_query: Query<&Window, With<PrimaryWindow>>,
+) {
+    let Ok(ctx) = contexts.ctx_mut() else { return };
+    let Ok(primary_window) = primary_window_query.single() else { return };
+
+    let surface_width = primary_window.resolution.physical_width() as f32;
+    let surface_height = primary_window.resolution.physical_height() as f32;
+    if surface_width < 1.0 || surface_height < 1.0 {
+        return;
+    }
+
+    let mut clear_viewports = || {
+        if let Ok(mut gizmo) = gizmo_camera_query.single_mut() {
+            gizmo.viewport = None;
+        }
+    };
+
+    let Some(active_camera) = viewport_camera_state.active_camera() else {
+        clear_viewports();
+        return;
+    };
+
+    if !editor_state.active {
+        if let Ok(mut camera) = camera_query.get_mut(active_camera) {
+            camera.viewport = None;
+        }
+        clear_viewports();
+        return;
+    }
+
+    let available_rect = ctx.available_rect();
+    if available_rect.width() <= 1.0 || available_rect.height() <= 1.0 {
+        if let Ok(mut camera) = camera_query.get_mut(active_camera) {
+            camera.viewport = None;
+        }
+        clear_viewports();
+        return;
+    }
+
+    // Clamp the egui rect against the full window rect so we never request a viewport outside the surface.
+    let scale = ctx.pixels_per_point();
+    let mut min_px = (available_rect.min * scale).floor();
+    let mut max_px = (available_rect.max * scale).ceil();
+
+    min_px.x = min_px.x.clamp(0.0, surface_width);
+    min_px.y = min_px.y.clamp(0.0, surface_height);
+    max_px.x = max_px.x.clamp(min_px.x, surface_width);
+    max_px.y = max_px.y.clamp(min_px.y, surface_height);
+
+    if max_px.x - min_px.x < 1.0 || max_px.y - min_px.y < 1.0 {
+        if let Ok(mut camera) = camera_query.get_mut(active_camera) {
+            camera.viewport = None;
+        }
+        clear_viewports();
+        return;
+    }
+
+    let viewport = Viewport {
+        physical_position: UVec2::new(min_px.x as u32, min_px.y as u32),
+        physical_size: UVec2::new((max_px.x - min_px.x) as u32, (max_px.y - min_px.y) as u32),
+        ..Default::default()
+    };
+
+    if viewport.physical_size.x == 0 || viewport.physical_size.y == 0 {
+        if let Ok(mut camera) = camera_query.get_mut(active_camera) {
+            camera.viewport = None;
+        }
+        clear_viewports();
+        return;
+    }
+
+    if let Ok(mut camera) = camera_query.get_mut(active_camera) {
+        camera.viewport = Some(viewport.clone());
+    }
+    if let Ok(mut gizmo_camera) = gizmo_camera_query.single_mut() {
+        gizmo_camera.viewport = Some(viewport);
+    }
+}
+
+pub fn sync_gizmo_camera_state(
+    viewport_camera_state: Res<ViewportCameraState>,
+    editor_state: Res<EditorState>,
+    gizmo_visibility: Res<GizmoVisibilityState>,
+    mut gizmo_camera_query: Query<(&mut Camera, &mut Transform), With<GizmoCamera>>,
+    active_camera_query: Query<
+        &Transform,
+        (With<Camera3d>, Without<UICamera>, Without<GizmoCamera>),
+    >,
+) {
+    let Ok((mut gizmo_camera, mut gizmo_transform)) = gizmo_camera_query.single_mut() else {
+        return;
+    };
+
+    let should_render = editor_state.active && gizmo_visibility.active;
+    gizmo_camera.is_active = should_render;
+
+    if !should_render {
+        gizmo_camera.viewport = None;
+        return;
+    }
+
+    let Some(active_entity) = viewport_camera_state.active_camera() else {
+        gizmo_camera.is_active = false;
+        gizmo_camera.viewport = None;
+        return;
+    };
+
+    if let Ok(active_transform) = active_camera_query.get(active_entity) {
+        *gizmo_transform = active_transform.clone();
     }
 }
 

--- a/crates/bevy_granite_editor/src/viewport/grid.rs
+++ b/crates/bevy_granite_editor/src/viewport/grid.rs
@@ -1,71 +1,199 @@
-use crate::editor_state::EditorState;
+use crate::{editor_state::EditorState, viewport::camera::LAYER_GRID};
 use bevy::{
-    gizmos::gizmos::Gizmos,
+    asset::RenderAssetUsages,
     math::Vec3,
-    prelude::{Color, Query, Res, With},
-    transform::components::GlobalTransform,
+    mesh::{Indices, Mesh3d},
+    pbr::{MeshMaterial3d, StandardMaterial},
+    prelude::{
+        AlphaMode, Assets, Color, Commands, Component, GlobalTransform, Mesh, Name, Query, Res,
+        ResMut, Transform, Visibility, With,
+    },
+    render::render_resource::PrimitiveTopology,
 };
-use bevy_granite_core::UICamera;
+use bevy_granite_core::{EditorIgnore, UICamera};
 
-fn draw_infinite_grid(
-    mut gizmos: Gizmos,
-    camera_transform: &GlobalTransform,
-    max_distance: f32,
-    color: [f32; 4],
-    size: f32,
+#[derive(Component)]
+pub struct ViewportGrid;
+
+const MIN_CELL_SIZE: f32 = 0.0001;
+const MIN_LINE_THICKNESS: f32 = 0.0005;
+const GRID_EPSILON: f32 = 0.0001;
+const GRID_HEIGHT_OFFSET: f32 = 0.0;
+const GRID_DEPTH_BIAS: f32 = 1000.0; // Ensure grid renders on top of most things without z-fighting
+
+pub fn spawn_viewport_grid(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    let cell_size = size;
-    let camera_pos = camera_transform.translation();
-    let camera_x = camera_pos.x;
-    let camera_z = camera_pos.z;
+    let mesh = meshes.add(Mesh::new(
+        PrimitiveTopology::TriangleList,
+        RenderAssetUsages::default(),
+    ));
+    let material = materials.add(StandardMaterial {
+        base_color: Color::srgba(0.6, 0.6, 0.6, 0.5),
+        alpha_mode: AlphaMode::Blend,
+        unlit: true,
+        fog_enabled: false,
+        cull_mode: None,
+        depth_bias: GRID_DEPTH_BIAS,
+        ..Default::default()
+    });
 
-    let start_x = camera_x - max_distance;
-    let end_x = camera_x + max_distance;
-    let start_z = camera_z - max_distance;
-    let end_z = camera_z + max_distance;
+    commands.spawn((
+        Name::new("Viewport Grid"),
+        ViewportGrid,
+        Mesh3d(mesh),
+        MeshMaterial3d(material),
+        Transform::IDENTITY,
+        GlobalTransform::IDENTITY,
+        Visibility::Hidden,
+        EditorIgnore::PICKING,
+        bevy::camera::visibility::RenderLayers::layer(LAYER_GRID),
+    ));
+}
+
+pub fn update_grid_system(
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+    mut grid_query: Query<
+        (
+            &Mesh3d,
+            &MeshMaterial3d<StandardMaterial>,
+            &mut Visibility,
+        ),
+        With<ViewportGrid>,
+    >,
+    camera_query: Query<&bevy::transform::components::GlobalTransform, With<UICamera>>,
+    editor_state: Res<EditorState>,
+) {
+    let Ok((mesh_handle, material_handle, mut visibility)) = grid_query.single_mut() else {
+        return;
+    };
+
+    if !editor_state.active || !editor_state.config.viewport.grid {
+        *visibility = Visibility::Hidden;
+        return;
+    }
+
+    let Ok(camera_transform) = camera_query.single() else {
+        *visibility = Visibility::Hidden;
+        return;
+    };
+
+    let max_distance = editor_state.config.viewport.grid_distance.max(MIN_CELL_SIZE);
+    let cell_size = editor_state
+        .config
+        .viewport
+        .grid_size
+        .max(MIN_CELL_SIZE);
+    let line_thickness = (cell_size * 0.05).max(MIN_LINE_THICKNESS);
+    let color = editor_state.config.viewport.grid_color;
+
+    if let Some(material) = materials.get_mut(&material_handle.0) {
+        material.base_color = Color::srgba(color[0], color[1], color[2], color[3]);
+        material.alpha_mode = AlphaMode::Blend;
+        material.unlit = true;
+        material.fog_enabled = false;
+        material.cull_mode = None;
+        material.depth_bias = GRID_DEPTH_BIAS;
+    }
+
+    let (positions, normals, uvs, indices) =
+        build_grid_geometry(camera_transform, max_distance, cell_size, line_thickness);
+
+    if positions.is_empty() {
+        *visibility = Visibility::Hidden;
+        return;
+    }
+
+    *visibility = Visibility::Visible;
+
+    if let Some(mesh) = meshes.get_mut(&mesh_handle.0) {
+        let mut new_mesh = Mesh::new(
+            PrimitiveTopology::TriangleList,
+            RenderAssetUsages::default(),
+        );
+        new_mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, positions);
+        new_mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
+        new_mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, uvs);
+        new_mesh.insert_indices(Indices::U32(indices));
+        *mesh = new_mesh;
+    }
+}
+
+fn build_grid_geometry(
+    camera_transform: &bevy::transform::components::GlobalTransform,
+    max_distance: f32,
+    cell_size: f32,
+    line_thickness: f32,
+) -> (Vec<[f32; 3]>, Vec<[f32; 3]>, Vec<[f32; 2]>, Vec<u32>) {
+    let camera_pos = camera_transform.translation();
+    let center_x = camera_pos.x;
+    let center_z = camera_pos.z;
+
+    let start_x = center_x - max_distance;
+    let end_x = center_x + max_distance;
+    let start_z = center_z - max_distance;
+    let end_z = center_z + max_distance;
 
     let first_x = (start_x / cell_size).floor() * cell_size;
     let first_z = (start_z / cell_size).floor() * cell_size;
 
+    let mut positions = Vec::new();
+    let mut normals = Vec::new();
+    let mut uvs = Vec::new();
+    let mut indices = Vec::new();
+
+    let mut add_quad = |a: Vec3, b: Vec3, c: Vec3, d: Vec3| {
+        let base_index = positions.len() as u32;
+        positions.push(a.to_array());
+        positions.push(b.to_array());
+        positions.push(c.to_array());
+        positions.push(d.to_array());
+
+        let normal = Vec3::Y;
+        normals.extend([normal.to_array(); 4]);
+        uvs.extend([[0.0, 0.0]; 4]);
+
+        indices.extend_from_slice(&[
+            base_index,
+            base_index + 2,
+            base_index + 1,
+            base_index + 2,
+            base_index + 3,
+            base_index + 1,
+        ]);
+    };
+
+    let half_thickness = line_thickness * 0.5;
     let mut x = first_x;
-    while x <= end_x {
-        if (camera_pos - Vec3::new(x, 0.0, camera_z)).length() <= max_distance {
-            gizmos.line(
-                Vec3::new(x, 0.0, start_z),
-                Vec3::new(x, 0.0, end_z),
-                Color::srgba(color[0], color[1], color[2], color[3]),
-            );
+    while x <= end_x + GRID_EPSILON {
+        let distance = (camera_pos - Vec3::new(x, 0.0, center_z)).length();
+        if distance <= max_distance + cell_size {
+            let y = GRID_HEIGHT_OFFSET;
+            let a = Vec3::new(x - half_thickness, y, start_z);
+            let b = Vec3::new(x + half_thickness, y, start_z);
+            let c = Vec3::new(x - half_thickness, y, end_z);
+            let d = Vec3::new(x + half_thickness, y, end_z);
+            add_quad(a, b, c, d);
         }
         x += cell_size;
     }
 
     let mut z = first_z;
-    while z <= end_z {
-        if (camera_pos - Vec3::new(camera_x, 0.0, z)).length() <= max_distance {
-            gizmos.line(
-                Vec3::new(start_x, 0.0, z),
-                Vec3::new(end_x, 0.0, z),
-                Color::srgba(color[0], color[1], color[2], color[3]),
-            );
+    while z <= end_z + GRID_EPSILON {
+        let distance = (camera_pos - Vec3::new(center_x, 0.0, z)).length();
+        if distance <= max_distance + cell_size {
+            let y = GRID_HEIGHT_OFFSET;
+            let a = Vec3::new(start_x, y, z - half_thickness);
+            let b = Vec3::new(start_x, y, z + half_thickness);
+            let c = Vec3::new(end_x, y, z - half_thickness);
+            let d = Vec3::new(end_x, y, z + half_thickness);
+            add_quad(a, b, c, d);
         }
         z += cell_size;
     }
-}
 
-pub fn update_grid_system(
-    gizmos: Gizmos,
-    camera_query: Query<&GlobalTransform, With<UICamera>>,
-    editor_state: Res<EditorState>,
-) {
-    if !editor_state.active {
-        return;
-    }
-    if let Ok(camera_transform) = camera_query.single() {
-        if editor_state.config.viewport.grid {
-            let max_distance = editor_state.config.viewport.grid_distance;
-            let color = editor_state.config.viewport.grid_color;
-            let size = editor_state.config.viewport.grid_size;
-            draw_infinite_grid(gizmos, camera_transform, max_distance, color, size);
-        }
-    }
+    (positions, normals, uvs, indices)
 }

--- a/crates/bevy_granite_editor/src/viewport/plugin.rs
+++ b/crates/bevy_granite_editor/src/viewport/plugin.rs
@@ -1,32 +1,23 @@
 use super::camera::{
-    add_editor_camera,
-    add_ui_camera,
-    camera_frame_system,
-    camera_sync_toggle_system,
-    enforce_viewport_camera_state,
-    handle_viewport_camera_override_requests,
-    mouse_button_iter,
-    restore_runtime_camera_state,
-    sync_cameras_system,
-    CameraSyncState,
-    CameraTarget,
-    InputState,
-    ViewportCameraState,
+    add_editor_camera, add_gizmo_overlay_camera, add_ui_camera, camera_frame_system,
+    camera_sync_toggle_system, enforce_viewport_camera_state, gizmo_layers, grid_layers,
+    handle_viewport_camera_override_requests, mouse_button_iter, restore_runtime_camera_state,
+    sync_cameras_system, sync_gizmo_camera_state, update_viewport_camera_viewports_system,
+    CameraSyncState, CameraTarget, InputState, ViewportCameraState,
 };
 use crate::{
     setup::is_editor_active,
     viewport::{
-        cleanup_icon_entities_system, icons::register_embedded_class_icons,
-        relationship_line_system, show_active_selection_bounds_system, show_camera_forward_system,
+        cleanup_icon_entities_system, grid::{spawn_viewport_grid, update_grid_system},
+        icons::register_embedded_class_icons, relationship_line_system,
+        show_active_selection_bounds_system, show_camera_forward_system,
         show_directional_light_forward_system, show_empty_origin_system,
         show_point_light_range_system, show_selected_entities_bounds_system,
-        spawn_icon_entities_system, update_grid_system, update_icon_entities_system, DebugRenderer,
-        SelectionRenderer,
+        spawn_icon_entities_system, update_icon_entities_system, DebugRenderer, SelectionRenderer,
     },
 };
 use bevy::{
     app::{PostUpdate, Startup},
-    camera::visibility::RenderLayers,
     ecs::schedule::{common_conditions::not, ApplyDeferred, IntoScheduleConfigs}, // from #78
     gizmos::{
         config::{DefaultGizmoConfigGroup, GizmoConfig},
@@ -35,6 +26,7 @@ use bevy::{
     prelude::{App, Plugin, Update},
     transform::TransformSystems,
 };
+use bevy_egui::EguiPrimaryContextPass;
 
 pub struct ViewportPlugin;
 impl Plugin for ViewportPlugin {
@@ -51,11 +43,18 @@ impl Plugin for ViewportPlugin {
             // Debug gizmo groups/config
             //
             .init_gizmo_group::<DefaultGizmoConfigGroup>()
+            .insert_gizmo_config(
+                DefaultGizmoConfigGroup,
+                GizmoConfig {
+                    render_layers: grid_layers(),
+                    ..Default::default()
+                },
+            )
             .init_gizmo_group::<SelectionRenderer>()
             .insert_gizmo_config(
                 SelectionRenderer,
                 GizmoConfig {
-                    render_layers: RenderLayers::from_layers(&[14]), // 14 is our UI/Gizmo layer.
+                    render_layers: gizmo_layers(),
                     ..Default::default()
                 },
             )
@@ -64,7 +63,7 @@ impl Plugin for ViewportPlugin {
                 DebugRenderer,
                 GizmoConfig {
                     depth_bias: -1.0,
-                    render_layers: RenderLayers::from_layers(&[14]), // 14 is our UI/Gizmo layer.
+                    render_layers: gizmo_layers(),
                     ..Default::default()
                 },
             )
@@ -76,27 +75,27 @@ impl Plugin for ViewportPlugin {
                 Startup,
                 (
                     add_editor_camera,
+                    add_gizmo_overlay_camera,
                     add_ui_camera,
+                    spawn_viewport_grid,
                     ApplyDeferred,
                     bevy_egui::update_ui_size_and_scale_system,
                 )
                     .chain(),
             )
-            .add_systems(
-                Update,
-                (
-                    update_grid_system,
-                    mouse_button_iter, // FIX: Use UserInput
-                    camera_frame_system,
-                    camera_sync_toggle_system,
-                )
-                    .run_if(is_editor_active),
-            )
+            .add_systems(Update, update_grid_system.run_if(is_editor_active))
+            .add_systems(Update, mouse_button_iter.run_if(is_editor_active)) // FIX: Use UserInput
+            .add_systems(Update, camera_frame_system.run_if(is_editor_active))
+            .add_systems(Update, camera_sync_toggle_system.run_if(is_editor_active))
             .add_systems(
                 Update,
                 (handle_viewport_camera_override_requests, enforce_viewport_camera_state)
                     .chain()
                     .run_if(is_editor_active),
+            )
+            .add_systems(
+                EguiPrimaryContextPass,
+                update_viewport_camera_viewports_system.run_if(is_editor_active),
             )
             .add_systems(
                 Update,
@@ -123,6 +122,13 @@ impl Plugin for ViewportPlugin {
                     .after(TransformSystems::Propagate)
                     .run_if(is_editor_active),
             )
-            .add_systems(PostUpdate, sync_cameras_system.run_if(is_editor_active));
+            .add_systems(
+                PostUpdate,
+                (
+                    sync_cameras_system.run_if(is_editor_active),
+                    sync_gizmo_camera_state,
+                )
+                    .chain(),
+            );
     }
 }

--- a/crates/bevy_granite_gizmos/src/camera.rs
+++ b/crates/bevy_granite_gizmos/src/camera.rs
@@ -79,11 +79,12 @@ pub fn add_gizmo_camera(
             ))
             .insert(Camera {
                 order: 1,
+                clear_color: bevy::camera::ClearColorConfig::None,
                 ..Default::default()
             })
             .insert(TreeHiddenEntity)
             .insert(GizmoCamera)
-            .insert(RenderLayers::from_layers(&[0, 14])) // 14 is our UI/Gizmo layer.
+            .insert(RenderLayers::from_layers(&[14])) // 14 is our Gizmo layer.
             .id();
     }
 }


### PR DESCRIPTION
Redesign viewport rendering system to use three distinct cameras with isolated render layers, replacing the previous mixed-responsibility approach. This fixes critical rendering artifacts and viewport management issues.

Camera Architecture:
- UICamera for egui rendering and camera control via sync systems on dedicated layer
  * Full-screen with no clear color, independent scaling
  * Never receives shared viewport transform

- EditorViewportCamera (scene view) with scene+grid layers
  * Control managed via CameraSyncState
  * Supports temporary scene camera override in editor mode
  * Viewport rect matched to egui viewport space

- GizmoCamera (overlay) for decoupled gizmo rendering
  * Viewport rect matched to egui viewport space

Camera Override System:
- Update ViewportCameraState component
  * Stores editor camera, optional override, and original render layers
  * Enables camera switching with state restoration

- Implement handle_viewport_camera_override_requests
  * Preserves layer configuration before override
  * Forces override camera onto scene+grid layers
  * Transfers control to UI camera temporarily

- Update sync_cameras_system
  * Syncs UI camera with active scene camera
  * Isolates GizmoCamera (follow-only)

Render Layer Management:
- Add centralized layer constants (viewport/camera/constants.rs)
  * scene_layers(), gizmo_layers(), grid_layers(), ui_layers()
  * Prevents typo-based layer mismatches

- Repoint DefaultGizmoConfigGroup to grid_layers()
  * Grid gizmos render only in viewport camera
  * SelectionRenderer and other groups use gizmo layer

- Implement temporary layer promotion for override cameras
  * Store old RenderLayers in ViewportCameraState
  * Restore on override exit to avoid permanent mutation

Grid Rendering Overhaul:
- Replace Gizmos::line billboard rendering with mesh-based approach
  * Fixes "fat line" artifact caused by screen-space billboards at grazing angles (bevy_gizmos-0.17.2/src/lines.wgsl behavior)
  * Billboard extrusion maintains pixel thickness regardless of perspective, causing massive ribbons at shallow angles
  * Believe this is a new artifact as of 0.17, as the same visual artifact was not visible in 0.16

- Add ViewportGrid mesh system (viewport/grid.rs)
  * spawn_viewport_grid creates true world geometry
  * update_grid_system rebuilds quad strip each frame based on editor settings (cell size, distance, color)
  * Apparent width now correctly scales with camera angle

- Implement z-fighting prevention
  * StandardMaterial depth_bias configured to prevent z-fighting

Viewport Synchronization:
- Perform viewport updates in EguiPrimaryContextPass
  * Fixes crash when available_rect() called outside Context::run()
  * Computes egui-available rect and multiplies by pixels-per-point

- Update viewport rectangle management
  * Applies to active scene camera + gizmo camera
  * Clears custom viewport when editor inactive (Bevy fullscreen)

- Implement gizmo camera activity toggle
  * sync_gizmo_camera_state controls is_active based on editor/gizmo visibility resource
  * Copies active camera transform for alignment in edit and runtime

Fixes:
- Grid no longer renders as thick ribbons at grazing angles
- Viewport rect calculation no longer panics outside egui context
- Camera overrides properly restore render layers
- Gizmos correctly align with viewport in all camera modes