### PR TITLE
fixed crash is side panel is to large

### DIFF
--- a/crates/bevy_granite_editor/src/interface/layout/dock.rs
+++ b/crates/bevy_granite_editor/src/interface/layout/dock.rs
@@ -83,7 +83,9 @@ pub fn dock_ui_system(
     let screen_width = screen_rect.width();
     let screen_height = screen_rect.height();
 
-    let right_panel_width = (screen_width * 0.10).clamp(200., 1000.);
+    let default_side_panel_width = (screen_width * 0.10).clamp(200., 1000.);
+    // we need a way to calculate the minimum size the bottom panel can be so if we change it in the future it wont start crashing again
+    let max_side_panel_width = screen_width - 270.; // 270 is the minimum size to fit bottom panel it will crash is smaller than this
     let bottom_panel_height = (screen_height * 0.05).clamp(100., 400.);
 
     let space = get_interface_config_float("ui.spacing");
@@ -112,8 +114,8 @@ pub fn dock_ui_system(
             left = true;
             egui::SidePanel::left("left_dock_panel")
                 .resizable(true)
-                .default_width(right_panel_width)
-                .width_range(250.0..=(screen_width * 0.9))
+                .default_width(default_side_panel_width)
+                .width_range(250.0..=max_side_panel_width)
                 .show(ctx, |ui| {
                     DockArea::new(&mut side_dock.dock_state)
                         .id(egui::Id::new("left_dock_area"))
@@ -123,8 +125,8 @@ pub fn dock_ui_system(
         SidePanelPosition::Right => {
             egui::SidePanel::right("right_dock_panel")
                 .resizable(true)
-                .default_width(right_panel_width)
-                .width_range(250.0..=(screen_width * 0.9))
+                .default_width(default_side_panel_width)
+                .width_range(250.0..=max_side_panel_width)
                 .show(ctx, |ui| {
                     DockArea::new(&mut side_dock.dock_state)
                         .id(egui::Id::new("right_dock_area"))

--- a/crates/bevy_granite_editor/src/interface/layout/dock.rs
+++ b/crates/bevy_granite_editor/src/interface/layout/dock.rs
@@ -149,8 +149,8 @@ pub fn dock_ui_system(
     let size = ctx.available_rect();
     for (_, _, mut camera, _, _, _, viewportcamera) in camera_query.iter_mut() {
         if viewportcamera.is_some() {
-            let width = (size.width() * 1.5) as u32;
-            let height = (size.height() * 1.5) as u32;
+            let width = (size.width() * ctx.pixels_per_point()) as u32;
+            let height = (size.height() * ctx.pixels_per_point()) as u32;
             let Some(viewport) = camera.viewport.as_mut() else {
                 continue;
             };
@@ -159,7 +159,7 @@ pub fn dock_ui_system(
             } else {
                 viewport.physical_position.x = 0;
             }
-            viewport.physical_position.y = (size.min.y * 1.5) as u32;
+            viewport.physical_position.y = (size.min.y * ctx.pixels_per_point()) as u32;
             viewport.physical_size = bevy::prelude::UVec2::new(width, height);
         }
     }


### PR DESCRIPTION
fixed #84.

This is only a stopgap; I hardcoded a minimum gap so the bottom panel can fit. We need a way to calculate this minimum or change the layout so the bottom bar is all the way across, like the top bar