### PR TITLE
Mockup of Bevy Remote Editor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.dependencies]
-bevy = { version = "0.17.2", default-features = false }
+bevy = { version = "0.17.2", default-features = true, features = ["bevy_remote"]}
 bevy-inspector-egui = "0.34.0"
 bevy_obj = "0.17.0"
 bevy_egui = "0.37.0"
@@ -39,10 +39,22 @@ bevy_granite_macros = { path = "crates/bevy_granite_macros", optional = true }
 
 [dev-dependencies]
 serde = "*"
+serde_json = "*"
+ureq = { version = "3.0.8", features = ["json"] }
+anyhow = "*"
 
 [[example]]
 name = "dungeon"
 required-features = ["bevy/bevy_winit"]
+
+[[example]]
+name = "brp_editor"
+required-features = ["bevy/bevy_winit", "bevy/bevy_remote"]
+
+[[example]]
+name = "brp_server"
+required-features = ["bevy/bevy_winit", "bevy/bevy_remote"]
+
 
 [profile.dev]
 opt-level = 1

--- a/crates/bevy_granite_editor/Cargo.toml
+++ b/crates/bevy_granite_editor/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.3.0"
 edition = "2021"
 
 [dependencies]
-bevy = { workspace = true, features = ["bevy_winit"]}
+bevy = { workspace = true, features = ["bevy_winit", "bevy_ui"]}
 toml = { workspace = true }
 bevy-inspector-egui = { workspace = true }
 bevy_egui = { workspace = true }

--- a/crates/bevy_granite_editor/src/interface/layout/dock.rs
+++ b/crates/bevy_granite_editor/src/interface/layout/dock.rs
@@ -83,7 +83,9 @@ pub fn dock_ui_system(
     let screen_width = screen_rect.width();
     let screen_height = screen_rect.height();
 
-    let right_panel_width = (screen_width * 0.10).clamp(200., 1000.);
+    let default_side_panel_width = (screen_width * 0.10).clamp(200., 1000.);
+    // we need a way to calculate the minimum size the bottom panel can be so if we change it in the future it wont start crashing again
+    let max_side_panel_width = screen_width - 270.; // 270 is the minimum size to fit bottom panel it will crash is smaller than this
     let bottom_panel_height = (screen_height * 0.05).clamp(100., 400.);
 
     let space = get_interface_config_float("ui.spacing");
@@ -112,8 +114,8 @@ pub fn dock_ui_system(
             left = true;
             egui::SidePanel::left("left_dock_panel")
                 .resizable(true)
-                .default_width(right_panel_width)
-                .width_range(250.0..=(screen_width * 0.9))
+                .default_width(default_side_panel_width)
+                .width_range(250.0..=max_side_panel_width)
                 .show(ctx, |ui| {
                     DockArea::new(&mut side_dock.dock_state)
                         .id(egui::Id::new("left_dock_area"))
@@ -123,8 +125,8 @@ pub fn dock_ui_system(
         SidePanelPosition::Right => {
             egui::SidePanel::right("right_dock_panel")
                 .resizable(true)
-                .default_width(right_panel_width)
-                .width_range(250.0..=(screen_width * 0.9))
+                .default_width(default_side_panel_width)
+                .width_range(250.0..=max_side_panel_width)
                 .show(ctx, |ui| {
                     DockArea::new(&mut side_dock.dock_state)
                         .id(egui::Id::new("right_dock_area"))

--- a/crates/bevy_granite_editor/src/interface/layout/dock.rs
+++ b/crates/bevy_granite_editor/src/interface/layout/dock.rs
@@ -149,8 +149,8 @@ pub fn dock_ui_system(
     let size = ctx.available_rect();
     for (_, _, mut camera, _, _, _, viewportcamera) in camera_query.iter_mut() {
         if viewportcamera.is_some() {
-            let width = (size.width() * 1.5) as u32;
-            let height = (size.height() * 1.5) as u32;
+            let width = (size.width() * ctx.pixels_per_point()) as u32;
+            let height = (size.height() * ctx.pixels_per_point()) as u32;
             let Some(viewport) = camera.viewport.as_mut() else {
                 continue;
             };
@@ -159,7 +159,7 @@ pub fn dock_ui_system(
             } else {
                 viewport.physical_position.x = 0;
             }
-            viewport.physical_position.y = (size.min.y * 1.5) as u32;
+            viewport.physical_position.y = (size.min.y * ctx.pixels_per_point()) as u32;
             viewport.physical_size = bevy::prelude::UVec2::new(width, height);
         }
     }

--- a/examples/brp_editor.rs
+++ b/examples/brp_editor.rs
@@ -1,0 +1,251 @@
+use std::any::type_name;
+
+use bevy::{
+    core_pipeline::tonemapping::Tonemapping,
+    prelude::*,
+    remote::{
+        builtin_methods::{
+            BrpMutateComponentsParams, BrpQuery, BrpQueryFilter, BrpQueryParams,
+            BRP_MUTATE_COMPONENTS_METHOD, BRP_QUERY_METHOD,
+        },
+        BrpRequest,
+    },
+    window::{PrimaryWindow, WindowResolution},
+};
+
+const URL: &str = "http://localhost:15702";
+
+fn main() {
+    let mut app = App::new();
+    // need this to run not on the main thread
+    // this wont be a problem in a real use case since it would be its own executable
+    app.add_plugins(DefaultPlugins);
+
+    app.add_systems(Startup, hyjack_main_game_window);
+    app.add_systems(PreStartup, spawn_fake_editor_ui);
+    app.insert_resource(Time::<Fixed>::from_hz(5.));
+    app.add_systems(FixedUpdate, sync_window_to_view);
+    // app.add_systems(PostStartup, test_editor_hide_decorations);
+    app.run();
+}
+
+// this fuction will get the entity of the main game window using BRP then it will hide the window decorations
+fn hyjack_main_game_window(mut commands: Commands) {
+    println!("Hyjacking main game window to remove decorations");
+    let window = get_game_window(URL).expect("IDK");
+    hide_decorations(URL, window).expect("IDK");
+    commands.insert_resource(GameWindow(window));
+}
+
+fn test_editor_hide_decorations(mut window: Single<&mut Window, With<PrimaryWindow>>) {
+    let reflect = window.as_reflect_mut();
+    let p = reflect.reflect_path_mut("decorations").unwrap();
+    *p.try_downcast_mut::<bool>().unwrap() = false;
+}
+
+fn spawn_fake_editor_ui(mut commands: Commands) {
+    println!("Spawning fake editor ui");
+    commands.spawn((Camera2d, Tonemapping::None));
+    commands.spawn((
+        Node {
+            width: percent(100),
+            height: percent(100),
+            flex_direction: FlexDirection::Column,
+            ..default()
+        },
+        BackgroundColor(Color::linear_rgb(1., 0.1, 0.1)),
+        children![
+            (
+                Name::new("Fake Top Bar"),
+                Node {
+                    width: Val::Percent(100.0),
+                    height: Val::Px(30.),
+                    top: Val::Px(0.),
+                    ..Default::default()
+                },
+                Text::new("Fake Top Bar"),
+                BackgroundColor(Color::linear_rgb(1., 0., 0.)),
+            ),
+            (
+                Node {
+                    width: Val::Percent(100.0),
+                    height: Val::Auto,
+                    flex_direction: FlexDirection::Row,
+                    flex_grow: 1.0,
+                    ..Default::default()
+                },
+                children![
+                    (
+                        Viewport,
+                        Name::new("Fake Left Panel"),
+                        Node {
+                            width: Val::Percent(75.0),
+                            height: Val::Auto,
+                            left: Val::Px(0.),
+                            ..Default::default()
+                        },
+                        Text::new("Fake Left Panel"),
+                        BackgroundColor(Color::linear_rgb(1., 1., 1.)),
+                    ),
+                    (
+                        Name::new("Fake Side Panel"),
+                        Node {
+                            width: Val::Percent(25.0),
+                            height: Val::Auto,
+                            right: Val::Px(0.),
+                            ..Default::default()
+                        },
+                        Text::new("Fake Side Panel"),
+                        BackgroundColor(Color::linear_rgb(0., 1., 0.)),
+                    ),
+                ]
+            ),
+            (
+                Name::new("Fake Bottom Bar"),
+                Node {
+                    width: Val::Percent(100.0),
+                    height: Val::Px(100.),
+                    bottom: Val::Px(0.),
+                    ..Default::default()
+                },
+                Text::new("Fake Bottom Bar"),
+                BackgroundColor(Color::linear_rgb(0., 0., 1.)),
+            ),
+        ],
+    ));
+    println!("Fake editor ui spawned");
+}
+
+#[derive(Component)]
+struct Viewport;
+
+#[derive(Resource)]
+struct GameWindow(Entity);
+
+fn get_game_window(url: &str) -> Result<Entity, anyhow::Error> {
+    let get_transform_request = BrpRequest {
+        jsonrpc: String::from("2.0"),
+        method: String::from(BRP_QUERY_METHOD),
+        id: Some(serde_json::to_value(1)?),
+        params: Some(
+            serde_json::to_value(BrpQueryParams {
+                data: BrpQuery {
+                    components: vec![],
+                    ..Default::default()
+                },
+                strict: false,
+                filter: BrpQueryFilter {
+                    with: vec![type_name::<Window>().to_string()],
+                    ..Default::default()
+                },
+            })
+            .expect("Unable to convert query parameters to a valid JSON value"),
+        ),
+    };
+    // bevy::prelude::info!("transform request: {get_transform_request:#?}");
+    let res = ureq::post(url)
+        .send_json(get_transform_request)?
+        .body_mut()
+        .read_json::<serde_json::Value>()?;
+    let e = serde_json::from_value(res["result"][0]["entity"].clone())?;
+    println!("game window entity: {e:?}");
+    Ok(e)
+}
+
+fn hide_decorations(url: &str, window: Entity) -> Result<(), anyhow::Error> {
+    let set_no_decorations_request = BrpRequest {
+        jsonrpc: String::from("2.0"),
+        method: String::from(BRP_MUTATE_COMPONENTS_METHOD),
+        id: Some(serde_json::to_value(1)?),
+        params: Some(serde_json::to_value(BrpMutateComponentsParams {
+            entity: window,
+            component: String::from(type_name::<Window>()),
+            path: String::from("decorations"),
+            value: serde_json::to_value(false)?,
+        })?),
+    };
+    let res = ureq::post(url)
+        .send_json(set_no_decorations_request)?
+        .body_mut()
+        .read_json::<serde_json::Value>()?;
+    println!("{res:#}");
+    Ok(())
+}
+
+fn sync_window_to_view(
+    viewport: Single<(&ComputedNode, &UiTransform), With<Viewport>>,
+    mut window: Single<&mut Window, With<PrimaryWindow>>,
+    game_window: Res<GameWindow>,
+) {
+    if window.position == WindowPosition::Automatic {
+        window.position = WindowPosition::At(IVec2::ZERO);
+    }
+    let (node, transform) = viewport.into_inner();
+    println!("{} {:?} {:?}", node.size(), window.position, transform);
+    send_sync_command(node.size().as_uvec2(), window.position, URL, game_window.0).expect("IDK");
+}
+
+fn send_sync_command(
+    size: UVec2,
+    position: WindowPosition,
+    url: &str,
+    window: Entity,
+) -> Result<(), anyhow::Error> {
+    let WindowPosition::At(mut pos) = position else {
+        return Ok(());
+    };
+    pos.y += 30 + 30; // window decorations + fake top bar
+
+    let set_no_decorations_request = BrpRequest {
+        jsonrpc: String::from("2.0"),
+        method: String::from(BRP_MUTATE_COMPONENTS_METHOD),
+        id: Some(serde_json::to_value(1)?),
+        params: Some(serde_json::to_value(BrpMutateComponentsParams {
+            entity: window,
+            component: String::from(type_name::<Window>()),
+            path: String::from("position"),
+            value: serde_json::to_value(WindowPosition::At(pos))?,
+        })?),
+    };
+    let res = ureq::post(url)
+        .send_json(set_no_decorations_request)?
+        .body_mut()
+        .read_json::<serde_json::Value>()?;
+
+    println!("sync position res: {res:#?}");
+
+    let set_no_decorations_request = BrpRequest {
+        jsonrpc: String::from("2.0"),
+        method: String::from(BRP_MUTATE_COMPONENTS_METHOD),
+        id: Some(serde_json::to_value(1)?),
+        params: Some(serde_json::to_value(BrpMutateComponentsParams {
+            entity: window,
+            component: String::from(type_name::<Window>()),
+            path: String::from("resolution"),
+            value: serde_json::to_value(WindowResolution::new(size.x, size.y))?,
+        })?),
+    };
+    let res = ureq::post(url)
+        .send_json(set_no_decorations_request)?
+        .body_mut()
+        .read_json::<serde_json::Value>()?;
+
+    println!("sync resolution res: {res:#?}");
+    let set_no_decorations_request = BrpRequest {
+        jsonrpc: String::from("2.0"),
+        method: String::from(BRP_MUTATE_COMPONENTS_METHOD),
+        id: Some(serde_json::to_value(1)?),
+        params: Some(serde_json::to_value(BrpMutateComponentsParams {
+            entity: window,
+            component: String::from(type_name::<Window>()),
+            path: String::from("focused"),
+            value: serde_json::to_value(true)?,
+        })?),
+    };
+    let res = ureq::post(url)
+        .send_json(set_no_decorations_request)?
+        .body_mut()
+        .read_json::<serde_json::Value>()?;
+    println!("set focused res: {res:#?}");
+    Ok(())
+}

--- a/examples/brp_server.rs
+++ b/examples/brp_server.rs
@@ -1,0 +1,66 @@
+//dungeon.scene designed by Noah Booker
+use bevy::{
+    prelude::*,
+    remote::{http::RemoteHttpPlugin, RemotePlugin},
+};
+use bevy_granite::prelude::*;
+use bevy_granite_core::entities::SaveSettings;
+
+const STARTING_WORLD: &str = "scenes/dungeon.scene";
+
+#[granite_component]
+struct MyTestComponent {
+    value: i32,
+}
+
+#[granite_component("default")]
+struct AnotherComponent {
+    message: String,
+}
+
+impl Default for AnotherComponent {
+    fn default() -> Self {
+        AnotherComponent {
+            message: "Hello, Granite!".to_string(),
+        }
+    }
+}
+
+fn main() {
+    let path = "./target/debug/examples/brp_editor.exe";
+    let mut _editor = std::process::Command::new(path)
+        .spawn()
+        .expect("failed to start editor");
+    let mut app = App::new();
+    register_editor_components!();
+
+    app.add_plugins(DefaultPlugins)
+        .add_plugins(bevy_granite::BevyGranite {
+            default_world: STARTING_WORLD.to_string(),
+            ..Default::default()
+        })
+        .add_plugins((RemotePlugin::default(), RemoteHttpPlugin::default()))
+        .add_systems(Startup, setup)
+        .add_systems(Update, close_if_editor_closed)
+        .insert_resource(EditorHandle(_editor))
+        .run();
+    // _ = _editor.wait();
+}
+
+fn setup(mut open_event: MessageWriter<RequestLoadEvent>) {
+    open_event.write(RequestLoadEvent(
+        STARTING_WORLD.to_string(),
+        SaveSettings::Runtime,
+        None,
+    ));
+}
+
+#[derive(Resource, Deref, DerefMut)]
+struct EditorHandle(std::process::Child);
+
+fn close_if_editor_closed(mut editor: ResMut<EditorHandle>, mut exit: MessageWriter<AppExit>) {
+    if let Ok(Some(_)) = editor.try_wait() {
+        println!("Editor closed, shutting down game.");
+        exit.write(AppExit::default());
+    }
+}


### PR DESCRIPTION
TBH, this is a bit silly, we would need to make our own connection layer as HTTP is far far too slow for real-time.

Basically, every 5 seconds, the editor tells the game to move to where its viewport is and be on top. This could easily be set to only when the editor moves in a real application; the big limitation is how long it takes to make an HTTP request, it's on the order of seconds, and it's blocking, so the editor is basically unusable. I'm sure this could be fixed with a WebSocket or some other interprocess communication method that doesn't have such high latency.

Definitely don't want this merged since I had to turn on default features to get it rendering UI, but just want to show the proof of concept of making two applications look like 1.