### PR TITLE
Fix objects jitter when applying transformations.

### DIFF
--- a/crates/bevy_granite_gizmos/src/gizmos/plugin.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/plugin.rs
@@ -6,8 +6,12 @@ use super::{
     RotateInitDragEvent, RotateResetDragEvent, SpawnGizmoEvent, TransformDraggingEvent,
     TransformInitDragEvent, TransformResetDragEvent,
 };
+use crate::gizmos::transform::{
+    apply_transformations, TransitionDelta,
+};
 use crate::gizmos::{GizmoMode, NewGizmoType};
 use crate::is_gizmos_active;
+use bevy::ecs::schedule::common_conditions::any_with_component;
 use bevy::{
     app::{App, Plugin, PostUpdate, Startup, Update},
     ecs::schedule::IntoScheduleConfigs,
@@ -52,7 +56,12 @@ impl Plugin for GizmoPlugin {
             .add_systems(Startup, register_embedded_rotate_gizmo_mesh)
             .add_systems(
                 Update,
-                (gizmo_changed_watcher, gizmo_events).run_if(is_gizmos_active),
+                (
+                    gizmo_changed_watcher,
+                    gizmo_events,
+                    apply_transformations.run_if(any_with_component::<TransitionDelta>),
+                )
+                    .run_if(is_gizmos_active),
             )
             .add_systems(
                 Update,

--- a/crates/bevy_granite_gizmos/src/gizmos/transform/drag.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/transform/drag.rs
@@ -8,11 +8,16 @@ use crate::{
 use bevy::{
     asset::Assets,
     ecs::{
-        component::Component, hierarchy::ChildOf, message::MessageWriter, observer::On,
+        component::Component,
+        hierarchy::ChildOf,
+        message::MessageWriter,
+        observer::On,
         system::Commands,
     },
     gizmos::{retained::Gizmo, GizmoAsset},
-    picking::events::{Drag, DragStart, Pointer, Press},
+    picking::
+        events::{Drag, DragStart, Pointer, Press}
+    ,
     prelude::{
         Entity, GlobalTransform, Query, Res, ResMut, Resource, Transform, Vec3, With, Without,
     },
@@ -30,6 +35,7 @@ pub struct TransformDuplicationState {
 
 pub fn drag_transform_gizmo(
     event: On<Pointer<Drag>>,
+    mut command: Commands,
     targets: Query<&GizmoOf>,
     camera_query: Query<(Entity, &GlobalTransform, &bevy::camera::Camera), With<GizmoCamera>>,
     mut objects: Query<&mut Transform>,
@@ -140,7 +146,7 @@ pub fn drag_transform_gizmo(
         }
     };
 
-    let world_delta = match (axis, typ) {
+    let mut world_delta = match (axis, typ) {
         (GizmoAxis::None, _) => Vec3::ZERO,
         (GizmoAxis::X, TransformGizmo::Axis) => {
             let Some(click_distance) = click_ray.intersect_plane(
@@ -237,20 +243,17 @@ pub fn drag_transform_gizmo(
     };
 
     // Apply the delta to all root selected entities
-    for &entity in &root_entities {
-        if let Ok(mut entity_transform) = objects.get_mut(entity) {
+    if world_delta.length() > 0.0 {
+        for &entity in &root_entities {
             if let Ok(parent) = parents.get(entity) {
                 if let Ok(parent_global) = global_transforms.get(parent.parent()) {
                     let parent_rotation_inv =
                         parent_global.to_scale_rotation_translation().1.inverse();
                     let parent_local_delta = parent_rotation_inv * world_delta;
-                    entity_transform.translation += parent_local_delta;
-                } else {
-                    entity_transform.translation += world_delta;
+                    world_delta = parent_local_delta;
                 }
-            } else {
-                entity_transform.translation += world_delta;
             }
+            command.entity(entity).insert(TransitionDelta(world_delta));
         }
     }
 
@@ -258,6 +261,16 @@ pub fn drag_transform_gizmo(
         if let Ok(mut camera_transform) = objects.get_mut(c_entity) {
             camera_transform.translation += world_delta;
         }
+    }
+}
+
+pub fn apply_transformations(
+    mut command: Commands,
+    objects: Query<(Entity, &mut Transform, &TransitionDelta)>,
+) {
+    for (entity, mut transform, transition_delta) in objects {
+        transform.translation += transition_delta.0;
+        command.entity(entity).remove::<TransitionDelta>();
     }
 }
 
@@ -371,3 +384,6 @@ pub fn cleanup_axis_line(
 
 #[derive(Component)]
 pub struct AxisLine;
+
+#[derive(Component)]
+pub struct TransitionDelta(Vec3);


### PR DESCRIPTION
Don't know if it's just me, but when I apply transformations to the objects using mouse drag, the affected object seem to jitter a lot. 
This seem to happen because transformation is immediately applied on `observer` call. Which not necessary happens on the right time in call schedule.

https://github.com/user-attachments/assets/2fc4034c-d016-4298-a717-7db546ef3cb5

By extracting transform application to the separate function that always runs on `Update` schedule jittering issue disappears.

https://github.com/user-attachments/assets/12b8668d-489e-4865-be70-4c38c73e9b46
