### PR TITLE
Fix gizmo to cursor snap

### DIFF
--- a/crates/bevy_granite_gizmos/src/gizmos/transform/gizmo.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/transform/gizmo.rs
@@ -188,6 +188,8 @@ fn build_gizmo_sphere(
             GizmoOf(root),
             ChildOf(parent),
         ))
+        .observe(super::drag::calculate_drag_offset)
+        .observe(super::drag::drag_end_cleanup)
         .observe(super::drag::drag_transform_gizmo)
         .observe(super::drag::dragstart_transform_gizmo);
 }
@@ -237,6 +239,8 @@ fn build_axis_cylinder(
         .insert(TransformGizmo::Axis)
         .insert(GizmoMesh)
         .insert(ChildOf(parent))
+        .observe(super::drag::calculate_drag_offset)
+        .observe(super::drag::drag_end_cleanup)
         .observe(super::drag::drag_transform_gizmo)
         .observe(super::drag::dragstart_transform_gizmo)
         .with_children(|p| {
@@ -300,6 +304,8 @@ fn build_axis_plane(
             GizmoMesh,
             ChildOf(parent),
         ))
+        .observe(super::drag::calculate_drag_offset)
+        .observe(super::drag::drag_end_cleanup)
         .observe(super::drag::drag_transform_gizmo)
         .observe(super::drag::dragstart_transform_gizmo);
 }

--- a/crates/bevy_granite_gizmos/src/input/drag.rs
+++ b/crates/bevy_granite_gizmos/src/input/drag.rs
@@ -86,4 +86,8 @@ impl GizmoAxis {
             GizmoAxis::None => (GizmoAxis::None, GizmoAxis::None),
         }
     }
+
+    pub fn plane_as_vec3(self) -> Vec3 {
+        self.plane().0.to_vec3() + self.plane().1.to_vec3()
+    }
 }

--- a/crates/bevy_granite_gizmos/src/selection/manager.rs
+++ b/crates/bevy_granite_gizmos/src/selection/manager.rs
@@ -137,7 +137,7 @@ pub fn handle_picking_selection(
     if on_click.button != bevy::picking::pointer::PointerButton::Primary {
         return;
     }
-    match ignored.get(on_click.entity) {
+    match ignored.get(on_click.trigger().original_event_target) {
         Ok(to_ignore) => {
             if to_ignore.contains(EditorIgnore::PICKING) {
                 return;


### PR DESCRIPTION
Fixes an unpleasant snap of the object to the cursor when we start position change. 

https://github.com/user-attachments/assets/d678600b-14ca-47dc-9540-388d520ac0ba

1. Fixes #96 
2. Additionally a change of how drag of different axis is handled, should work practically the same with a lot less repetition, can move this part to the separate PR if necessary.   