### PR TITLE
Added local gizmo mode functionality 

### DIFF
--- a/crates/bevy_granite_gizmos/src/gizmos/distance_scaling.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/distance_scaling.rs
@@ -10,13 +10,14 @@ use bevy::{
 use super::{GizmoChildren, GizmoType};
 use crate::{
     gizmos::{NewGizmoType, GizmoConfig},
-    NewGizmoConfig, GizmoCamera,
+    NewGizmoConfig,
 };
+use bevy_granite_core::UICamera;
 
 const DISTANCE_SCALING_ENABLED: bool = true;
 
 pub fn scale_gizmo_by_camera_distance_system(
-    camera_q: Query<&GlobalTransform, With<GizmoCamera>>,
+    camera_q: Query<&GlobalTransform, With<UICamera>>,
     mut gizmo_q: Query<
         (&GlobalTransform, &mut Transform, Option<&mut GizmoConfig>),
         With<GizmoChildren>,

--- a/crates/bevy_granite_gizmos/src/gizmos/mod.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/mod.rs
@@ -178,10 +178,10 @@ pub use manager::{gizmo_changed_watcher, gizmo_events};
 pub use plugin::GizmoPlugin;
 pub use rotate::{
     despawn_rotate_gizmo, handle_init_rotate_drag, handle_rotate_dragging, handle_rotate_input,
-    handle_rotate_reset, register_embedded_rotate_gizmo_mesh, spawn_rotate_gizmo, RotateGizmo,
-    RotateGizmoParent,
+    handle_rotate_reset, register_embedded_rotate_gizmo_mesh, spawn_rotate_gizmo, 
+    RotateGizmo, RotateGizmoParent,
 };
 pub use transform::{
-    despawn_transform_gizmo, spawn_transform_gizmo, PreviousTransformGizmo, TransformGizmo,
-    TransformGizmoParent,
+    despawn_transform_gizmo, spawn_transform_gizmo, update_gizmo_rotation_for_mode, 
+    PreviousTransformGizmo, TransformGizmo, TransformGizmoParent,
 };

--- a/crates/bevy_granite_gizmos/src/gizmos/mod.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/mod.rs
@@ -53,7 +53,7 @@ impl NewGizmoConfig {
     }
 }
 
-#[derive(Component, Clone, Copy)]
+#[derive(Component, Clone, Copy, Debug)]
 pub enum GizmoConfig {
     Pointer,
     None,
@@ -179,9 +179,10 @@ pub use plugin::GizmoPlugin;
 pub use rotate::{
     despawn_rotate_gizmo, handle_init_rotate_drag, handle_rotate_dragging, handle_rotate_input,
     handle_rotate_reset, register_embedded_rotate_gizmo_mesh, spawn_rotate_gizmo, 
+    update_gizmo_rotation_for_mode as update_rotate_gizmo_rotation_for_mode,
     RotateGizmo, RotateGizmoParent,
 };
 pub use transform::{
-    despawn_transform_gizmo, spawn_transform_gizmo, update_gizmo_rotation_for_mode, 
+    despawn_transform_gizmo, spawn_transform_gizmo, update_gizmo_rotation_for_mode as update_transform_gizmo_rotation_for_mode, 
     PreviousTransformGizmo, TransformGizmo, TransformGizmoParent,
 };

--- a/crates/bevy_granite_gizmos/src/gizmos/plugin.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/plugin.rs
@@ -5,9 +5,10 @@ use super::{
     GizmoType, LastSelectedGizmo, NewGizmoConfig, PreviousTransformGizmo, RotateDraggingEvent,
     RotateInitDragEvent, RotateResetDragEvent, SpawnGizmoEvent, TransformDraggingEvent,
     TransformInitDragEvent, TransformResetDragEvent,
+    update_rotate_gizmo_rotation_for_mode, update_transform_gizmo_rotation_for_mode,
 };
 use crate::gizmos::transform::{
-    apply_transformations, update_gizmo_rotation_for_mode, TransitionDelta,
+    apply_transformations, TransitionDelta,
 };
 use crate::gizmos::{GizmoMode, NewGizmoType};
 use crate::is_gizmos_active;
@@ -59,7 +60,8 @@ impl Plugin for GizmoPlugin {
                 (
                     gizmo_changed_watcher,
                     gizmo_events,
-                    update_gizmo_rotation_for_mode,
+                    update_transform_gizmo_rotation_for_mode,
+                    update_rotate_gizmo_rotation_for_mode,
                     apply_transformations.run_if(any_with_component::<TransitionDelta>),
                 )
                     .run_if(is_gizmos_active),

--- a/crates/bevy_granite_gizmos/src/gizmos/plugin.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/plugin.rs
@@ -7,7 +7,7 @@ use super::{
     TransformInitDragEvent, TransformResetDragEvent,
 };
 use crate::gizmos::transform::{
-    apply_transformations, TransitionDelta,
+    apply_transformations, update_gizmo_rotation_for_mode, TransitionDelta,
 };
 use crate::gizmos::{GizmoMode, NewGizmoType};
 use crate::is_gizmos_active;
@@ -59,6 +59,7 @@ impl Plugin for GizmoPlugin {
                 (
                     gizmo_changed_watcher,
                     gizmo_events,
+                    update_gizmo_rotation_for_mode,
                     apply_transformations.run_if(any_with_component::<TransitionDelta>),
                 )
                     .run_if(is_gizmos_active),

--- a/crates/bevy_granite_gizmos/src/gizmos/rotate/drag.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/rotate/drag.rs
@@ -16,7 +16,6 @@ use crate::{
 use bevy::{
     camera::Camera,
     ecs::{observer::On, query::Changed},
-    math::primitives::InfinitePlane3d,
     picking::{
         events::{Drag, Pointer, Press},
         hover::PickingInteraction,
@@ -24,7 +23,7 @@ use bevy::{
     },
     prelude::{
         ChildOf, Entity, GlobalTransform, MessageReader, MessageWriter, Mut, Name, ParamSet, Quat,
-        Query, Res, ResMut, Transform, Vec2, Vec3, Visibility, With, Without,
+        Query, Res, ResMut, Transform, Vec3, Visibility, With, Without,
     },
 };
 use bevy_granite_core::{CursorWindowPos, IconProxy, UserInput};
@@ -239,6 +238,8 @@ fn hide_unselected_axes(
     }
 }
 
+/// ANGULAR movement for locked axis. We dont want pixel delta for locked axis.
+/// Free rotate can use mouse delta
 pub fn handle_rotate_dragging(
     event: On<Pointer<Drag>>,
     targets: Query<&GizmoOf>,
@@ -252,7 +253,6 @@ pub fn handle_rotate_dragging(
     selected: Res<NewGizmoConfig>,
     gizmo_data: Query<(&GizmoAxis, Option<&GizmoConfig>)>,
     mut drag_state: ResMut<DragState>,
-    cursor_2d: Res<CursorWindowPos>,
 ) {
     if event.button != PointerButton::Primary {
         return;
@@ -282,7 +282,7 @@ pub fn handle_rotate_dragging(
         return;
     };
 
-    let free_rotate_speed = 0.3 * speed_scale;
+    let free_rotate_speed = 0.01 * speed_scale;
     let locked_rotate_speed = 1.0 * speed_scale;
 
     let Ok(_target) = targets.get(event.entity) else {
@@ -337,27 +337,22 @@ pub fn handle_rotate_dragging(
         }
     };
 
-    // Calculate rotation based on axis type
     let final_rotation = match gizmo_axis {
         GizmoAxis::All => {
-            // Free rotation using screen-space mouse delta
-            let cursor_delta_2d = cursor_2d.position - drag_state.initial_cursor_position;
+            let delta_x = event.delta.x * free_rotate_speed;
+            let delta_y = event.delta.y * free_rotate_speed;
             
-            if cursor_delta_2d == Vec2::ZERO {
+            let snapped_delta_x = snap_roation(delta_x, _gizmo_snap.rotate_value.to_radians());
+            let snapped_delta_y = snap_roation(delta_y, _gizmo_snap.rotate_value.to_radians());
+            
+            if snapped_delta_x.abs() < f32::EPSILON && snapped_delta_y.abs() < f32::EPSILON {
                 return;
             }
-
-            let yaw = cursor_delta_2d.x * free_rotate_speed;
-            let pitch = -cursor_delta_2d.y * free_rotate_speed;
             
-            let delta_x = yaw.to_radians();
-            let delta_y = pitch.to_radians();
-
-            Quat::from_axis_angle(camera_transform.up().as_vec3(), delta_x)
-                * Quat::from_axis_angle(camera_transform.right().as_vec3(), delta_y)
+            Quat::from_axis_angle(camera_transform.up().as_vec3(), snapped_delta_x)
+                * Quat::from_axis_angle(camera_transform.right().as_vec3(), snapped_delta_y)
         }
         GizmoAxis::X | GizmoAxis::Y | GizmoAxis::Z => {
-            // Locked axis rotation using ray-plane intersection
             let axis = match gizmo_axis {
                 GizmoAxis::X => Vec3::X,
                 GizmoAxis::Y => Vec3::Y,
@@ -387,8 +382,6 @@ pub fn handle_rotate_dragging(
 
             let t = (origin - ray_origin).dot(plane_normal) / ray_dir_dot;
             let hit_pos = ray_origin + ray_direction * t;
-            
-            // Calculate angle between previous and current hit direction
             let prev_vec = drag_state.prev_hit_dir;
             let curr_vec = (hit_pos - origin).normalize();
             
@@ -404,7 +397,6 @@ pub fn handle_rotate_dragging(
             }
             
             let unsigned_angle = prev_vec.angle_between(curr_vec);
-            
             if unsigned_angle.is_nan() || !unsigned_angle.is_finite() {
                 return;
             }
@@ -416,7 +408,6 @@ pub fn handle_rotate_dragging(
             
             let direction = prev_vec.cross(curr_vec).dot(axis).signum();
             let signed_angle = unsigned_angle * direction * locked_rotate_speed;
-            
             let rotation_delta = Quat::from_axis_angle(axis, signed_angle);
             
             drag_state.prev_hit_dir = curr_vec;
@@ -434,7 +425,6 @@ pub fn handle_rotate_dragging(
         }
     };
 
-    // Apply rotation to all root entities
     for &entity in &root_entities {
         if let Ok(mut entity_transform) = objects.get_mut(entity) {
             let relative_pos = entity_transform.translation - origin;

--- a/crates/bevy_granite_gizmos/src/gizmos/rotate/drag.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/rotate/drag.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 use bevy::{
     camera::Camera,
-    ecs::{observer::On, query::Changed, system::Local},
+    ecs::{observer::On, query::Changed},
     math::primitives::InfinitePlane3d,
     picking::{
         events::{Drag, Pointer, Press},
@@ -168,6 +168,8 @@ pub fn handle_init_rotate_drag(
             drag_state.gizmo_position = parent_global_transform.translation();
             drag_state.dragging = true;
             drag_state.locked_axis = Some(gizmo_axis);
+            drag_state.accumulated_angle = 0.0;
+            drag_state.last_snapped = 0.0;
 
             // Compute vector from gizmo to hit point
             let hit_vec = (raycast_cursor_pos.position - drag_state.gizmo_position).normalize();
@@ -240,10 +242,11 @@ pub fn handle_rotate_dragging(
     active_selection: Query<Entity, With<ActiveSelection>>,
     other_selected: Query<Entity, (With<Selected>, Without<ActiveSelection>)>,
     parents: Query<&ChildOf>,
-    gizmo_snap: Res<GizmoSnap>,
+    _gizmo_snap: Res<GizmoSnap>,
     selected: Res<NewGizmoConfig>,
     gizmo_data: Query<(&GizmoAxis, Option<&GizmoConfig>)>,
-    mut accrued: Local<Vec2>,
+    mut drag_state: ResMut<DragState>,
+    cursor_2d: Res<CursorWindowPos>,
 ) {
     if event.button != PointerButton::Primary {
         return;
@@ -274,26 +277,14 @@ pub fn handle_rotate_dragging(
     };
 
     let free_rotate_speed = 0.3 * speed_scale;
+    let locked_rotate_speed = 1.0 * speed_scale;
 
-    *accrued += event.delta * free_rotate_speed;
-
-    if accrued.x.abs() < gizmo_snap.rotate_value && accrued.y.abs() < gizmo_snap.rotate_value {
-        return;
-    }
-    let accrued_x_degrees = accrued.x;
-    let accrued_y_degrees = accrued.y;
-
-    let x_step = snap_roation(accrued_x_degrees, gizmo_snap.rotate_value);
-    let y_step = snap_roation(accrued_y_degrees, gizmo_snap.rotate_value);
-
-    let delta_x = x_step.to_radians();
-    let delta_y = y_step.to_radians();
     let Ok(_target) = targets.get(event.entity) else {
         log(
             LogType::Editor,
             LogLevel::Error,
             LogCategory::Debug,
-            format!("Rotaion Gizmo({})'s Target not found", event.entity.index()),
+            format!("Rotation Gizmo({})'s Target not found", event.entity.index()),
         );
         return;
     };
@@ -306,23 +297,7 @@ pub fn handle_rotate_dragging(
         );
         return;
     };
-    let effective_delta_x = delta_x;
-    let effective_delta_y = delta_y;
 
-    let rotation_delta = Quat::from_axis_angle(camera_transform.up().as_vec3(), delta_x)
-        * Quat::from_axis_angle(camera_transform.right().as_vec3(), delta_y);
-
-    let Ok(click_ray) = camera.viewport_to_world(camera_transform, event.pointer_location.position)
-    else {
-        log! {
-            LogType::Editor,
-            LogLevel::Error,
-            LogCategory::Input,
-            "Failed to convert viewport to world coordinates for pointer location: {:?}",
-            event.pointer_location.position
-        };
-        return;
-    };
     let mut all_selected_entities = Vec::new();
     all_selected_entities.extend(active_selection.iter());
     all_selected_entities.extend(other_selected.iter());
@@ -356,40 +331,82 @@ pub fn handle_rotate_dragging(
         }
     };
 
+    // Calculate rotation based on axis type
     let final_rotation = match gizmo_axis {
-        GizmoAxis::All => rotation_delta,
-        GizmoAxis::X => {
-            let mut delta = effective_delta_y;
-            if origin.x > camera_transform.translation().x {
-                delta = -delta;
+        GizmoAxis::All => {
+            // Free rotation using screen-space mouse delta
+            let cursor_delta_2d = cursor_2d.position - drag_state.initial_cursor_position;
+            
+            if cursor_delta_2d == Vec2::ZERO {
+                return;
             }
 
-            Quat::from_rotation_x(delta)
+            let yaw = cursor_delta_2d.x * free_rotate_speed;
+            let pitch = -cursor_delta_2d.y * free_rotate_speed;
+            
+            let delta_x = yaw.to_radians();
+            let delta_y = pitch.to_radians();
+
+            Quat::from_axis_angle(camera_transform.up().as_vec3(), delta_x)
+                * Quat::from_axis_angle(camera_transform.right().as_vec3(), delta_y)
         }
-        GizmoAxis::Y => {
-            let mut delta = effective_delta_x;
-            if origin.y > camera_transform.translation().y {
-                delta = -delta;
+        GizmoAxis::X | GizmoAxis::Y | GizmoAxis::Z => {
+            // Locked axis rotation using ray-plane intersection
+            let axis = match gizmo_axis {
+                GizmoAxis::X => Vec3::X,
+                GizmoAxis::Y => Vec3::Y,
+                GizmoAxis::Z => Vec3::Z,
+                _ => return,
+            };
+
+            let Ok(ray) = camera.viewport_to_world(camera_transform, event.pointer_location.position) else {
+                log! {
+                    LogType::Editor,
+                    LogLevel::Error,
+                    LogCategory::Input,
+                    "Failed to convert viewport to world coordinates for pointer location: {:?}",
+                    event.pointer_location.position
+                };
+                return;
+            };
+
+            let ray_origin = ray.origin;
+            let ray_direction = ray.direction;
+            let plane_normal = axis;
+            
+            // Ray-plane intersection
+            let ray_dir_dot = ray_direction.dot(plane_normal);
+            if ray_dir_dot.abs() < 1e-6 {
+                return; // Ray parallel to plane
             }
 
-            Quat::from_rotation_y(delta)
-        }
-        GizmoAxis::Z => {
-            let (pitch, roll, yaw) = rotation_delta.to_euler(bevy::math::EulerRot::XZY);
-            let mut delta = roll;
-            if let Some(hit_distance) = click_ray
-                .intersect_plane(Vec3::new(0., 0., origin.z), InfinitePlane3d::new(Vec3::Z))
-            {
-                let hit_point = camera_transform.translation() + click_ray.direction * hit_distance;
-                let y_diff = origin.y - hit_point.y;
-                let x_diff = origin.x - hit_point.x;
-                delta += yaw * y_diff.signum();
-                delta += pitch * x_diff.signum();
+            let t = (origin - ray_origin).dot(plane_normal) / ray_dir_dot;
+            let hit_pos = ray_origin + ray_direction * t;
+            
+            // Calculate angle between previous and current hit direction
+            let prev_vec = drag_state.prev_hit_dir;
+            let curr_vec = (hit_pos - origin).normalize();
+            
+            // Safety check for NaN or invalid vectors
+            if prev_vec.is_nan() || curr_vec.is_nan() || prev_vec.length_squared() < 1e-6 || curr_vec.length_squared() < 1e-6 {
+                drag_state.prev_hit_dir = curr_vec;
+                return;
             }
-            if origin.z > camera_transform.translation().z {
-                delta = -delta;
+            
+            let unsigned_angle = prev_vec.angle_between(curr_vec);
+            
+            // Check for NaN in angle calculation
+            if unsigned_angle.is_nan() || !unsigned_angle.is_finite() {
+                return;
             }
-            Quat::from_rotation_z(delta)
+            
+            let direction = prev_vec.cross(curr_vec).dot(axis).signum();
+            let signed_angle = unsigned_angle * direction * locked_rotate_speed;
+            
+            // Update for next frame
+            drag_state.prev_hit_dir = curr_vec;
+            
+            Quat::from_axis_angle(axis, signed_angle)
         }
         GizmoAxis::None => {
             log!(
@@ -401,6 +418,8 @@ pub fn handle_rotate_dragging(
             Quat::IDENTITY
         }
     };
+
+    // Apply rotation to all root entities
     for &entity in &root_entities {
         if let Ok(mut entity_transform) = objects.get_mut(entity) {
             let relative_pos = entity_transform.translation - origin;
@@ -409,9 +428,9 @@ pub fn handle_rotate_dragging(
             entity_transform.rotation = final_rotation * entity_transform.rotation;
         }
     }
-    *accrued = Vec2::ZERO;
 }
 
+#[allow(dead_code)]
 fn snap_roation(value: f32, inc: f32) -> f32 {
     if inc == 0.0 {
         value

--- a/crates/bevy_granite_gizmos/src/gizmos/rotate/drag.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/rotate/drag.rs
@@ -171,9 +171,15 @@ pub fn handle_init_rotate_drag(
             drag_state.accumulated_angle = 0.0;
             drag_state.last_snapped = 0.0;
 
-            // Compute vector from gizmo to hit point
-            let hit_vec = (raycast_cursor_pos.position - drag_state.gizmo_position).normalize();
-            drag_state.prev_hit_dir = hit_vec;
+            drag_state.prev_hit_dir = match gizmo_axis {
+                GizmoAxis::All => {
+                    (raycast_cursor_pos.position - drag_state.gizmo_position).normalize()
+                }
+                GizmoAxis::X | GizmoAxis::Y | GizmoAxis::Z => {
+                    (raycast_cursor_pos.position - drag_state.gizmo_position).normalize()
+                }
+                GizmoAxis::None => Vec3::ZERO,
+            };
 
             // Get and store initial gizmo rotation
             if let Ok((_, _gizmo_transform, gizmo_world_transform)) = queries.p5().single() {
@@ -374,7 +380,6 @@ pub fn handle_rotate_dragging(
             let ray_direction = ray.direction;
             let plane_normal = axis;
             
-            // Ray-plane intersection
             let ray_dir_dot = ray_direction.dot(plane_normal);
             if ray_dir_dot.abs() < 1e-6 {
                 return; // Ray parallel to plane
@@ -387,26 +392,36 @@ pub fn handle_rotate_dragging(
             let prev_vec = drag_state.prev_hit_dir;
             let curr_vec = (hit_pos - origin).normalize();
             
-            // Safety check for NaN or invalid vectors
             if prev_vec.is_nan() || curr_vec.is_nan() || prev_vec.length_squared() < 1e-6 || curr_vec.length_squared() < 1e-6 {
+                drag_state.prev_hit_dir = curr_vec;
+                return;
+            }
+            
+            let dot_product = prev_vec.dot(curr_vec);
+            if dot_product < 0.95 {
                 drag_state.prev_hit_dir = curr_vec;
                 return;
             }
             
             let unsigned_angle = prev_vec.angle_between(curr_vec);
             
-            // Check for NaN in angle calculation
             if unsigned_angle.is_nan() || !unsigned_angle.is_finite() {
                 return;
+            }
+            
+            let angle_threshold = 0.001; // ~0.057 degrees
+            if unsigned_angle.abs() < angle_threshold {
+                return; 
             }
             
             let direction = prev_vec.cross(curr_vec).dot(axis).signum();
             let signed_angle = unsigned_angle * direction * locked_rotate_speed;
             
-            // Update for next frame
+            let rotation_delta = Quat::from_axis_angle(axis, signed_angle);
+            
             drag_state.prev_hit_dir = curr_vec;
             
-            Quat::from_axis_angle(axis, signed_angle)
+            rotation_delta
         }
         GizmoAxis::None => {
             log!(

--- a/crates/bevy_granite_gizmos/src/gizmos/rotate/drag.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/rotate/drag.rs
@@ -473,9 +473,6 @@ pub fn handle_rotate_dragging(
                     }
                 }
                 GizmoMode::Global => {
-                    let relative_pos = entity_transform.translation - origin;
-                    let rotated_relative_pos = final_rotation * relative_pos;
-                    entity_transform.translation = origin + rotated_relative_pos;
                     entity_transform.rotation = final_rotation * entity_transform.rotation;
                 }
             }

--- a/crates/bevy_granite_gizmos/src/gizmos/rotate/drag.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/rotate/drag.rs
@@ -255,39 +255,14 @@ pub fn handle_rotate_dragging(
     gizmo_config_query: Query<&GizmoConfig>,
     mut drag_state: ResMut<DragState>,
 ) {
-    log!(
-        LogType::Editor,
-        LogLevel::Info,
-        LogCategory::Debug,
-        "handle_rotate_dragging called for entity: {:?}",
-        event.entity
-    );
-    
     if event.button != PointerButton::Primary {
         return;
     }
     let Ok((gizmo_axis, gizmo_root)) = gizmo_data.get(event.entity) else {
-        log!(
-            LogType::Editor,
-            LogLevel::Warning,
-            LogCategory::Input,
-            "Gizmo Axis data not found for Gizmo entity {:?}",
-            event.entity
-        );
         return;
     };
     
-    // Get config from parent gizmo entity
     let config = gizmo_config_query.get(gizmo_root.0).ok();
-    
-    log!(
-        LogType::Editor,
-        LogLevel::Info,
-        LogCategory::Debug,
-        "Gizmo config: {:?}, gizmo_axis: {:?}",
-        config,
-        gizmo_axis
-    );
     
     let GizmoConfig::Rotate {
         speed_scale,
@@ -295,12 +270,6 @@ pub fn handle_rotate_dragging(
         mode,
     } = config.cloned().unwrap_or(selected.rotation())
     else {
-        log!(
-            LogType::Editor,
-            LogLevel::Warning,
-            LogCategory::Input,
-            "Gizmo Config for rotation was not a Rotation Config",
-        );
         return;
     };
 
@@ -308,21 +277,9 @@ pub fn handle_rotate_dragging(
     let locked_rotate_speed = 1.0 * speed_scale;
 
     let Ok(target) = targets.get(event.entity) else {
-        log(
-            LogType::Editor,
-            LogLevel::Error,
-            LogCategory::Debug,
-            format!("Rotation Gizmo({})'s Target not found", event.entity.index()),
-        );
         return;
     };
     let Ok((camera_transform, camera)) = camera_query.single() else {
-        log!(
-            LogType::Editor,
-            LogLevel::Error,
-            LogCategory::Debug,
-            "Gizmo Camera not found for rotation drag"
-        );
         return;
     };
 
@@ -372,27 +329,49 @@ pub fn handle_rotate_dragging(
 
     let (final_rotation, local_axis) = match gizmo_axis {
         GizmoAxis::All => {
-            let delta_x = event.delta.x * free_rotate_speed;
-            let delta_y = event.delta.y * free_rotate_speed;
+            let snap_increment = _gizmo_snap.rotate_value.to_radians();
             
-            let snapped_delta_x = snap_roation(delta_x, _gizmo_snap.rotate_value.to_radians());
-            let snapped_delta_y = snap_roation(delta_y, _gizmo_snap.rotate_value.to_radians());
-            
-            if snapped_delta_x.abs() < f32::EPSILON && snapped_delta_y.abs() < f32::EPSILON {
-                return;
+            if snap_increment > 0.0 {
+                let delta_x = event.delta.x * free_rotate_speed;
+                let delta_y = event.delta.y * free_rotate_speed;
+                
+                let rotation_magnitude = (delta_x * delta_x + delta_y * delta_y).sqrt();
+                
+                drag_state.accumulated_angle += rotation_magnitude;
+                
+                let delta_from_last_snap = drag_state.accumulated_angle - drag_state.last_snapped;
+                if delta_from_last_snap.abs() >= snap_increment {
+                    let snap_count = (delta_from_last_snap / snap_increment).trunc();
+                    let snapped_magnitude = snap_count * snap_increment;
+                    
+                    let normalized_delta_x = if rotation_magnitude > f32::EPSILON {
+                        delta_x / rotation_magnitude
+                    } else {
+                        0.0
+                    };
+                    let normalized_delta_y = if rotation_magnitude > f32::EPSILON {
+                        delta_y / rotation_magnitude
+                    } else {
+                        0.0
+                    };
+                    
+                    let snapped_delta_x = normalized_delta_x * snapped_magnitude;
+                    let snapped_delta_y = normalized_delta_y * snapped_magnitude;
+                    
+                    drag_state.last_snapped += snapped_magnitude;
+                    let rotation = Quat::from_axis_angle(camera_transform.up().as_vec3(), snapped_delta_x)
+                        * Quat::from_axis_angle(camera_transform.right().as_vec3(), snapped_delta_y);
+                    (rotation, None)
+                } else {
+                    return;
+                }
+            } else {
+                let delta_x = event.delta.x * free_rotate_speed;
+                let delta_y = event.delta.y * free_rotate_speed;
+                let rotation = Quat::from_axis_angle(camera_transform.up().as_vec3(), delta_x)
+                    * Quat::from_axis_angle(camera_transform.right().as_vec3(), delta_y);
+                (rotation, None)
             }
-            
-            log!(
-                LogType::Editor,
-                LogLevel::Info,
-                LogCategory::Debug,
-                "Free rotation (All axis) - mode: {:?}",
-                mode
-            );
-            
-            let rotation = Quat::from_axis_angle(camera_transform.up().as_vec3(), snapped_delta_x)
-                * Quat::from_axis_angle(camera_transform.right().as_vec3(), snapped_delta_y);
-            (rotation, None)
         }
         GizmoAxis::X | GizmoAxis::Y | GizmoAxis::Z => {
             let axis = match gizmo_axis {
@@ -401,15 +380,6 @@ pub fn handle_rotate_dragging(
                 GizmoAxis::Z => Vec3::Z,
                 _ => return,
             };
-            
-            log!(
-                LogType::Editor,
-                LogLevel::Info,
-                LogCategory::Debug,
-                "Locked axis rotation: {:?}, mode: {:?}",
-                gizmo_axis,
-                mode
-            );
             
             // Apply local/global mode transformation
             let world_axis = match mode {
@@ -422,13 +392,6 @@ pub fn handle_rotate_dragging(
             };
 
             let Ok(ray) = camera.viewport_to_world(camera_transform, event.pointer_location.position) else {
-                log! {
-                    LogType::Editor,
-                    LogLevel::Error,
-                    LogCategory::Input,
-                    "Failed to convert viewport to world coordinates for pointer location: {:?}",
-                    event.pointer_location.position
-                };
                 return;
             };
 
@@ -469,19 +432,31 @@ pub fn handle_rotate_dragging(
             
             let direction = prev_vec.cross(curr_vec).dot(world_axis).signum();
             let signed_angle = unsigned_angle * direction * locked_rotate_speed;
-            let rotation_delta = Quat::from_axis_angle(world_axis, signed_angle);
             
+            // Apply snapping for locked axis rotation
+            let snap_increment = _gizmo_snap.rotate_value.to_radians();
+            let (snapped_angle, new_accumulated, new_last_snapped) = calculate_snap_rotation(
+                signed_angle,
+                drag_state.accumulated_angle,
+                drag_state.last_snapped,
+                snap_increment,
+            );
+            
+            // Update drag state
+            drag_state.accumulated_angle = new_accumulated;
+            drag_state.last_snapped = new_last_snapped;
             drag_state.prev_hit_dir = curr_vec;
             
-            (rotation_delta, Some((axis, signed_angle)))
+            // If no rotation should be applied yet (haven't crossed snap threshold)
+            if snapped_angle.abs() < f32::EPSILON {
+                return;
+            }
+            
+            let rotation_delta = Quat::from_axis_angle(world_axis, snapped_angle);
+            
+            (rotation_delta, Some((axis, snapped_angle)))
         }
         GizmoAxis::None => {
-            log!(
-                LogType::Editor,
-                LogLevel::Error,
-                LogCategory::Debug,
-                "Rotation Gizmo Axis None Should not happen",
-            );
             (Quat::IDENTITY, None)
         }
     };
@@ -490,26 +465,14 @@ pub fn handle_rotate_dragging(
         if let Ok(mut entity_transform) = objects.get_mut(entity) {
             match mode {
                 GizmoMode::Local => {
-                    // In local mode, rotation is applied in local space (position doesn't change)
                     if let Some((local_axis, signed_angle)) = local_axis {
-                        log!(
-                            LogType::Editor,
-                            LogLevel::Info,
-                            LogCategory::Debug,
-                            "Local mode: Rotating around {:?} by {} radians",
-                            local_axis,
-                            signed_angle
-                        );
-                        // Apply rotation in local space around the local axis
                         let local_rotation = Quat::from_axis_angle(local_axis, signed_angle);
                         entity_transform.rotation = entity_transform.rotation * local_rotation;
                     } else {
-                        // Free rotation (GizmoAxis::All) - apply in world space
                         entity_transform.rotation = final_rotation * entity_transform.rotation;
                     }
                 }
                 GizmoMode::Global => {
-                    // In global mode, rotation affects both position and rotation
                     let relative_pos = entity_transform.translation - origin;
                     let rotated_relative_pos = final_rotation * relative_pos;
                     entity_transform.translation = origin + rotated_relative_pos;
@@ -520,12 +483,27 @@ pub fn handle_rotate_dragging(
     }
 }
 
-#[allow(dead_code)]
-fn snap_roation(value: f32, inc: f32) -> f32 {
-    if inc == 0.0 {
-        value
+/// Calculates the snapped rotation angle based on accumulated rotation
+fn calculate_snap_rotation(
+    raw_delta: f32,
+    accumulated: f32,
+    last_snapped: f32,
+    snap_increment: f32,
+) -> (f32, f32, f32) {
+    if snap_increment == 0.0 || snap_increment.abs() < f32::EPSILON {
+        return (raw_delta, 0.0, 0.0);
+    }
+
+    let new_accumulated = accumulated + raw_delta;
+    let delta_from_last_snap = new_accumulated - last_snapped;
+    let snap_count = (delta_from_last_snap / snap_increment).trunc();
+    
+    if snap_count.abs() >= 1.0 {
+        let snapped_angle = snap_count * snap_increment;
+        let new_last_snapped = last_snapped + snapped_angle;
+        (snapped_angle, new_accumulated, new_last_snapped)
     } else {
-        (value / inc).round() * inc
+        (0.0, new_accumulated, last_snapped)
     }
 }
 

--- a/crates/bevy_granite_gizmos/src/gizmos/rotate/drag.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/rotate/drag.rs
@@ -381,7 +381,6 @@ pub fn handle_rotate_dragging(
                 _ => return,
             };
             
-            // Apply local/global mode transformation
             let world_axis = match mode {
                 GizmoMode::Local => {
                     target_rotation * axis
@@ -433,7 +432,6 @@ pub fn handle_rotate_dragging(
             let direction = prev_vec.cross(curr_vec).dot(world_axis).signum();
             let signed_angle = unsigned_angle * direction * locked_rotate_speed;
             
-            // Apply snapping for locked axis rotation
             let snap_increment = _gizmo_snap.rotate_value.to_radians();
             let (snapped_angle, new_accumulated, new_last_snapped) = calculate_snap_rotation(
                 signed_angle,
@@ -442,12 +440,10 @@ pub fn handle_rotate_dragging(
                 snap_increment,
             );
             
-            // Update drag state
             drag_state.accumulated_angle = new_accumulated;
             drag_state.last_snapped = new_last_snapped;
             drag_state.prev_hit_dir = curr_vec;
             
-            // If no rotation should be applied yet (haven't crossed snap threshold)
             if snapped_angle.abs() < f32::EPSILON {
                 return;
             }
@@ -473,7 +469,28 @@ pub fn handle_rotate_dragging(
                     }
                 }
                 GizmoMode::Global => {
-                    entity_transform.rotation = final_rotation * entity_transform.rotation;
+                    // Get the current global rotation
+                    // Apply the rotation in global space
+                    // Convert back to local space (accounting for parent rotation)
+                    
+                    let current_global_rotation = if let Ok(global_transform) = global_transforms.get(entity) {
+                        global_transform.to_scale_rotation_translation().1
+                    } else {
+                        entity_transform.rotation
+                    };
+                    
+                    let new_global_rotation = final_rotation * current_global_rotation;
+                    
+                    if let Ok(parent) = parents.get(entity) {
+                        if let Ok(parent_global) = global_transforms.get(parent.parent()) {
+                            let parent_rotation = parent_global.to_scale_rotation_translation().1;
+                            entity_transform.rotation = parent_rotation.inverse() * new_global_rotation;
+                        } else {
+                            entity_transform.rotation = new_global_rotation;
+                        }
+                    } else {
+                        entity_transform.rotation = new_global_rotation;
+                    }
                 }
             }
         }

--- a/crates/bevy_granite_gizmos/src/gizmos/rotate/drag.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/rotate/drag.rs
@@ -254,6 +254,7 @@ pub fn handle_rotate_dragging(
     gizmo_data: Query<(&GizmoAxis, &GizmoRoot)>,
     gizmo_config_query: Query<&GizmoConfig>,
     mut drag_state: ResMut<DragState>,
+    mut gizmo_visibility_query: Query<(&GizmoAxis, &mut Visibility, &GizmoRoot), With<RotateGizmo>>,
 ) {
     if event.button != PointerButton::Primary {
         return;
@@ -261,6 +262,19 @@ pub fn handle_rotate_dragging(
     let Ok((gizmo_axis, gizmo_root)) = gizmo_data.get(event.entity) else {
         return;
     };
+    
+    if !drag_state.dragging {
+        drag_state.dragging = true;
+        for (axis, mut visibility, root) in gizmo_visibility_query.iter_mut() {
+            if root.0 == gizmo_root.0 {
+                *visibility = if *axis == *gizmo_axis {
+                    Visibility::Visible
+                } else {
+                    Visibility::Hidden
+                };
+            }
+        }
+    }
     
     let config = gizmo_config_query.get(gizmo_root.0).ok();
     

--- a/crates/bevy_granite_gizmos/src/gizmos/rotate/drag.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/rotate/drag.rs
@@ -2,7 +2,7 @@
 // Children inherit rotation automatically through hierarchy
 use crate::{
     gizmos::{
-        GizmoConfig, GizmoMesh, GizmoOf, GizmoSnap, GizmoType, NewGizmoConfig, NewGizmoType,
+        GizmoConfig, GizmoMesh, GizmoMode, GizmoOf, GizmoRoot, GizmoSnap, GizmoType, NewGizmoConfig, NewGizmoType,
         RotateDraggingEvent, RotateGizmo, RotateGizmoParent, RotateInitDragEvent,
         RotateResetDragEvent,
     },
@@ -251,13 +251,22 @@ pub fn handle_rotate_dragging(
     parents: Query<&ChildOf>,
     _gizmo_snap: Res<GizmoSnap>,
     selected: Res<NewGizmoConfig>,
-    gizmo_data: Query<(&GizmoAxis, Option<&GizmoConfig>)>,
+    gizmo_data: Query<(&GizmoAxis, &GizmoRoot)>,
+    gizmo_config_query: Query<&GizmoConfig>,
     mut drag_state: ResMut<DragState>,
 ) {
+    log!(
+        LogType::Editor,
+        LogLevel::Info,
+        LogCategory::Debug,
+        "handle_rotate_dragging called for entity: {:?}",
+        event.entity
+    );
+    
     if event.button != PointerButton::Primary {
         return;
     }
-    let Ok((gizmo_axis, config)) = gizmo_data.get(event.entity) else {
+    let Ok((gizmo_axis, gizmo_root)) = gizmo_data.get(event.entity) else {
         log!(
             LogType::Editor,
             LogLevel::Warning,
@@ -267,10 +276,23 @@ pub fn handle_rotate_dragging(
         );
         return;
     };
+    
+    // Get config from parent gizmo entity
+    let config = gizmo_config_query.get(gizmo_root.0).ok();
+    
+    log!(
+        LogType::Editor,
+        LogLevel::Info,
+        LogCategory::Debug,
+        "Gizmo config: {:?}, gizmo_axis: {:?}",
+        config,
+        gizmo_axis
+    );
+    
     let GizmoConfig::Rotate {
         speed_scale,
         distance_scale: _,
-        mode: _,
+        mode,
     } = config.cloned().unwrap_or(selected.rotation())
     else {
         log!(
@@ -285,7 +307,7 @@ pub fn handle_rotate_dragging(
     let free_rotate_speed = 0.01 * speed_scale;
     let locked_rotate_speed = 1.0 * speed_scale;
 
-    let Ok(_target) = targets.get(event.entity) else {
+    let Ok(target) = targets.get(event.entity) else {
         log(
             LogType::Editor,
             LogLevel::Error,
@@ -336,8 +358,19 @@ pub fn handle_rotate_dragging(
             return;
         }
     };
+    
+    // Get target rotation for local/global mode
+    let target_rotation = if let Ok(global_transform) = global_transforms.get(target.0) {
+        global_transform.to_scale_rotation_translation().1
+    } else {
+        if let Ok(transform) = objects.get(target.0) {
+            transform.rotation
+        } else {
+            Quat::IDENTITY
+        }
+    };
 
-    let final_rotation = match gizmo_axis {
+    let (final_rotation, local_axis) = match gizmo_axis {
         GizmoAxis::All => {
             let delta_x = event.delta.x * free_rotate_speed;
             let delta_y = event.delta.y * free_rotate_speed;
@@ -349,8 +382,17 @@ pub fn handle_rotate_dragging(
                 return;
             }
             
-            Quat::from_axis_angle(camera_transform.up().as_vec3(), snapped_delta_x)
-                * Quat::from_axis_angle(camera_transform.right().as_vec3(), snapped_delta_y)
+            log!(
+                LogType::Editor,
+                LogLevel::Info,
+                LogCategory::Debug,
+                "Free rotation (All axis) - mode: {:?}",
+                mode
+            );
+            
+            let rotation = Quat::from_axis_angle(camera_transform.up().as_vec3(), snapped_delta_x)
+                * Quat::from_axis_angle(camera_transform.right().as_vec3(), snapped_delta_y);
+            (rotation, None)
         }
         GizmoAxis::X | GizmoAxis::Y | GizmoAxis::Z => {
             let axis = match gizmo_axis {
@@ -358,6 +400,25 @@ pub fn handle_rotate_dragging(
                 GizmoAxis::Y => Vec3::Y,
                 GizmoAxis::Z => Vec3::Z,
                 _ => return,
+            };
+            
+            log!(
+                LogType::Editor,
+                LogLevel::Info,
+                LogCategory::Debug,
+                "Locked axis rotation: {:?}, mode: {:?}",
+                gizmo_axis,
+                mode
+            );
+            
+            // Apply local/global mode transformation
+            let world_axis = match mode {
+                GizmoMode::Local => {
+                    target_rotation * axis
+                }
+                GizmoMode::Global => {
+                    axis
+                }
             };
 
             let Ok(ray) = camera.viewport_to_world(camera_transform, event.pointer_location.position) else {
@@ -373,7 +434,7 @@ pub fn handle_rotate_dragging(
 
             let ray_origin = ray.origin;
             let ray_direction = ray.direction;
-            let plane_normal = axis;
+            let plane_normal = world_axis;
             
             let ray_dir_dot = ray_direction.dot(plane_normal);
             if ray_dir_dot.abs() < 1e-6 {
@@ -406,13 +467,13 @@ pub fn handle_rotate_dragging(
                 return; 
             }
             
-            let direction = prev_vec.cross(curr_vec).dot(axis).signum();
+            let direction = prev_vec.cross(curr_vec).dot(world_axis).signum();
             let signed_angle = unsigned_angle * direction * locked_rotate_speed;
-            let rotation_delta = Quat::from_axis_angle(axis, signed_angle);
+            let rotation_delta = Quat::from_axis_angle(world_axis, signed_angle);
             
             drag_state.prev_hit_dir = curr_vec;
             
-            rotation_delta
+            (rotation_delta, Some((axis, signed_angle)))
         }
         GizmoAxis::None => {
             log!(
@@ -421,16 +482,40 @@ pub fn handle_rotate_dragging(
                 LogCategory::Debug,
                 "Rotation Gizmo Axis None Should not happen",
             );
-            Quat::IDENTITY
+            (Quat::IDENTITY, None)
         }
     };
 
     for &entity in &root_entities {
         if let Ok(mut entity_transform) = objects.get_mut(entity) {
-            let relative_pos = entity_transform.translation - origin;
-            let rotated_relative_pos = final_rotation * relative_pos;
-            entity_transform.translation = origin + rotated_relative_pos;
-            entity_transform.rotation = final_rotation * entity_transform.rotation;
+            match mode {
+                GizmoMode::Local => {
+                    // In local mode, rotation is applied in local space (position doesn't change)
+                    if let Some((local_axis, signed_angle)) = local_axis {
+                        log!(
+                            LogType::Editor,
+                            LogLevel::Info,
+                            LogCategory::Debug,
+                            "Local mode: Rotating around {:?} by {} radians",
+                            local_axis,
+                            signed_angle
+                        );
+                        // Apply rotation in local space around the local axis
+                        let local_rotation = Quat::from_axis_angle(local_axis, signed_angle);
+                        entity_transform.rotation = entity_transform.rotation * local_rotation;
+                    } else {
+                        // Free rotation (GizmoAxis::All) - apply in world space
+                        entity_transform.rotation = final_rotation * entity_transform.rotation;
+                    }
+                }
+                GizmoMode::Global => {
+                    // In global mode, rotation affects both position and rotation
+                    let relative_pos = entity_transform.translation - origin;
+                    let rotated_relative_pos = final_rotation * relative_pos;
+                    entity_transform.translation = origin + rotated_relative_pos;
+                    entity_transform.rotation = final_rotation * entity_transform.rotation;
+                }
+            }
         }
     }
 }

--- a/crates/bevy_granite_gizmos/src/gizmos/rotate/gizmo.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/rotate/gizmo.rs
@@ -7,7 +7,7 @@ use bevy::picking::Pickable;
 use bevy::prelude::{AlphaMode, Meshable, Quat, Sphere};
 use bevy::prelude::{
     Assets, Children, Color, Commands, Component, Entity, GlobalTransform, Mesh, Name, Query,
-    ResMut, Resource, StandardMaterial, Transform, Vec3, Visibility, Without,
+    ResMut, Resource, StandardMaterial, Transform, Vec3, Visibility, With, Without,
 };
 use bevy_granite_core::TreeHiddenEntity;
 use bevy_granite_logging::{
@@ -15,7 +15,7 @@ use bevy_granite_logging::{
     log,
 };
 
-use crate::gizmos::{GizmoConfig, GizmoOf, GizmoRoot};
+use crate::gizmos::{GizmoConfig, GizmoMode, GizmoOf, GizmoRoot};
 use crate::{gizmos::GizmoMesh, input::GizmoAxis};
 
 #[derive(Component)]
@@ -247,4 +247,26 @@ fn build_axis_ring(
             GizmoRoot(parent),
         ))
         .observe(super::drag::handle_rotate_dragging);
+}
+
+pub fn update_gizmo_rotation_for_mode(
+    mut gizmo_query: Query<(&mut Transform, &GizmoOf, &GizmoConfig), With<RotateGizmoParent>>,
+    parent_query: Query<&GlobalTransform>,
+) {
+    for (mut gizmo_transform, gizmo_of, config) in gizmo_query.iter_mut() {
+        if let Ok(parent_global_transform) = parent_query.get(gizmo_of.0) {
+            let parent_rotation = parent_global_transform.to_scale_rotation_translation().1;
+            
+            match config.mode() {
+                GizmoMode::Global => {
+                    // Counter-rotate to stay aligned with world axes
+                    gizmo_transform.rotation = parent_rotation.inverse();
+                }
+                GizmoMode::Local => {
+                    // Align with entity's rotation
+                    gizmo_transform.rotation = Quat::IDENTITY;
+                }
+            }
+        }
+    }
 }

--- a/crates/bevy_granite_gizmos/src/gizmos/rotate/gizmo.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/rotate/gizmo.rs
@@ -59,40 +59,21 @@ pub fn spawn_rotate_gizmo(
     if let Ok(parent_global_transform) = query.get(parent) {
         let gizmo_translation = offset;
 
-        let sphere = Sphere::new(ROTATE_VISUAL_RADIUS).mesh().ico(7).unwrap();
-        let sphere_handle = meshes.add(sphere);
-        let material = materials.add(StandardMaterial {
-            base_color: Color::srgba(0.6, 0.6, 0.6, 0.24),
-            unlit: true,
-            alpha_mode: AlphaMode::AlphaToCoverage,
-            ..Default::default()
-        });
-
-        // Set initial gizmo rotation based on mode
         let initial_rotation = match config.mode() {
             GizmoMode::Global => {
-                // Counter-rotate to stay aligned with world axes
                 parent_global_transform
                     .to_scale_rotation_translation()
                     .1
                     .inverse()
             }
             GizmoMode::Local => {
-                // Align with entity's rotation (identity in local space)
                 Quat::IDENTITY
             }
         };
 
+        // Create the gizmo parent entity 
         let gizmo_entity = commands
             .spawn((
-                Mesh3d(sphere_handle),
-                MeshMaterial3d(material.clone()),
-                NotShadowCaster,
-                NotShadowReceiver,
-                Pickable {
-                    is_hoverable: true,
-                    should_block_lower: false,
-                },
                 Transform {
                     translation: gizmo_translation,
                     rotation: initial_rotation,
@@ -104,12 +85,13 @@ pub fn spawn_rotate_gizmo(
                 config,
             ))
             .insert(Name::new("RotateGizmo"))
-            .insert(RotateGizmo)
             .insert(RotateGizmoParent)
             .insert(TreeHiddenEntity)
+            .insert(RotateGizmo)
             .id();
 
-        // commands.entity(gizmo_entity).insert(ParentTo(parent));
+        // Build the visual sphere as a child
+        build_visual_sphere(parent, commands, materials, gizmo_entity, meshes);
 
         build_free_sphere(
             parent,
@@ -177,6 +159,41 @@ pub fn despawn_rotate_gizmo(
             "Despawned Rotate Gizmo"
         );
     }
+}
+
+fn build_visual_sphere(
+    target: Entity,
+    commands: &mut Commands,
+    materials: &mut ResMut<Assets<StandardMaterial>>,
+    parent: Entity,
+    meshes: &mut ResMut<Assets<Mesh>>,
+) {
+    let sphere = Sphere::new(ROTATE_VISUAL_RADIUS).mesh().ico(7).unwrap();
+    let sphere_handle = meshes.add(sphere);
+    let material = materials.add(StandardMaterial {
+        base_color: Color::srgba(0.6, 0.6, 0.6, 0.24),
+        unlit: true,
+        alpha_mode: AlphaMode::AlphaToCoverage,
+        ..Default::default()
+    });
+
+    commands.spawn((
+        Mesh3d(sphere_handle),
+        MeshMaterial3d(material.clone()),
+        Transform::default(),
+        NotShadowCaster,
+        NotShadowReceiver,
+        Pickable {
+            is_hoverable: true,
+            should_block_lower: false,
+        },
+        Name::new("Gizmo Visual Sphere"),
+        GizmoAxis::None,
+        RotateGizmo,
+        ChildOf(parent),
+        GizmoOf(target),
+        GizmoRoot(parent),
+    ));
 }
 
 fn build_free_sphere(
@@ -271,10 +288,10 @@ pub fn update_gizmo_rotation_for_mode(
             match config.mode() {
                 GizmoMode::Global => {
                     // Mimic GlobalTransform
-                    // We want this to happen immediately, but GlobalTransform propagates later. So this is a workaround so we dont get gizmo off by one rotation 
+                    // We want this to happen immediately, but GlobalTransform propagates later. So this is a workaround so we dont get gizmo off by one rotation
                     let mut global_rotation = entity_transform.rotation;
                     let mut current_entity = gizmo_of.0;
-                    
+
                     while let Ok(parent_of) = parent_query.get(current_entity) {
                         let parent_entity = parent_of.parent();
                         if let Ok(parent_transform) = transform_query.get(parent_entity) {
@@ -284,7 +301,7 @@ pub fn update_gizmo_rotation_for_mode(
                             break;
                         }
                     }
-                    
+
                     gizmo_transform.rotation = global_rotation.inverse();
                 }
                 GizmoMode::Local => {

--- a/crates/bevy_granite_gizmos/src/gizmos/rotate/gizmo.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/rotate/gizmo.rs
@@ -68,6 +68,21 @@ pub fn spawn_rotate_gizmo(
             ..Default::default()
         });
 
+        // Set initial gizmo rotation based on mode
+        let initial_rotation = match config.mode() {
+            GizmoMode::Global => {
+                // Counter-rotate to stay aligned with world axes
+                parent_global_transform
+                    .to_scale_rotation_translation()
+                    .1
+                    .inverse()
+            }
+            GizmoMode::Local => {
+                // Align with entity's rotation (identity in local space)
+                Quat::IDENTITY
+            }
+        };
+
         let gizmo_entity = commands
             .spawn((
                 Mesh3d(sphere_handle),
@@ -80,10 +95,7 @@ pub fn spawn_rotate_gizmo(
                 },
                 Transform {
                     translation: gizmo_translation,
-                    rotation: parent_global_transform
-                        .to_scale_rotation_translation()
-                        .1
-                        .inverse(),
+                    rotation: initial_rotation,
                     ..Default::default()
                 },
                 Visibility::default(),
@@ -251,19 +263,31 @@ fn build_axis_ring(
 
 pub fn update_gizmo_rotation_for_mode(
     mut gizmo_query: Query<(&mut Transform, &GizmoOf, &GizmoConfig), With<RotateGizmoParent>>,
-    parent_query: Query<&Transform, Without<RotateGizmoParent>>,
+    transform_query: Query<&Transform, Without<RotateGizmoParent>>,
+    parent_query: Query<&ChildOf>,
 ) {
     for (mut gizmo_transform, gizmo_of, config) in gizmo_query.iter_mut() {
-        if let Ok(parent_transform) = parent_query.get(gizmo_of.0) {
-            let parent_rotation = parent_transform.rotation;
-            
+        if let Ok(entity_transform) = transform_query.get(gizmo_of.0) {
             match config.mode() {
                 GizmoMode::Global => {
-                    // Counter-rotate to stay aligned with world axes
-                    gizmo_transform.rotation = parent_rotation.inverse();
+                    // Mimic GlobalTransform
+                    // We want this to happen immediately, but GlobalTransform propagates later. So this is a workaround so we dont get gizmo off by one rotation 
+                    let mut global_rotation = entity_transform.rotation;
+                    let mut current_entity = gizmo_of.0;
+                    
+                    while let Ok(parent_of) = parent_query.get(current_entity) {
+                        let parent_entity = parent_of.parent();
+                        if let Ok(parent_transform) = transform_query.get(parent_entity) {
+                            global_rotation = parent_transform.rotation * global_rotation;
+                            current_entity = parent_entity;
+                        } else {
+                            break;
+                        }
+                    }
+                    
+                    gizmo_transform.rotation = global_rotation.inverse();
                 }
                 GizmoMode::Local => {
-                    // Align with entity's rotation
                     gizmo_transform.rotation = Quat::IDENTITY;
                 }
             }

--- a/crates/bevy_granite_gizmos/src/gizmos/rotate/gizmo.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/rotate/gizmo.rs
@@ -251,11 +251,11 @@ fn build_axis_ring(
 
 pub fn update_gizmo_rotation_for_mode(
     mut gizmo_query: Query<(&mut Transform, &GizmoOf, &GizmoConfig), With<RotateGizmoParent>>,
-    parent_query: Query<&GlobalTransform>,
+    parent_query: Query<&Transform, Without<RotateGizmoParent>>,
 ) {
     for (mut gizmo_transform, gizmo_of, config) in gizmo_query.iter_mut() {
-        if let Ok(parent_global_transform) = parent_query.get(gizmo_of.0) {
-            let parent_rotation = parent_global_transform.to_scale_rotation_translation().1;
+        if let Ok(parent_transform) = parent_query.get(gizmo_of.0) {
+            let parent_rotation = parent_transform.rotation;
             
             match config.mode() {
                 GizmoMode::Global => {

--- a/crates/bevy_granite_gizmos/src/gizmos/transform/drag.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/transform/drag.rs
@@ -175,7 +175,7 @@ pub fn drag_transform_gizmo(
             (axis_vec, camera_transform.forward().as_vec3())
         }
         TransformGizmo::Plane => {
-            let plane_vec = match gizmo_config.mode() {
+            let plane_normal = match gizmo_config.mode() {
                 GizmoMode::Local => {
                     target_rotation * axis.to_vec3()
                 }
@@ -183,15 +183,7 @@ pub fn drag_transform_gizmo(
                     axis.to_vec3()
                 }
             };
-            let active_vec = match gizmo_config.mode() {
-                GizmoMode::Local => {
-                    target_rotation * axis.plane_as_vec3()
-                }
-                GizmoMode::Global => {
-                    axis.plane_as_vec3()
-                }
-            };
-            (active_vec, plane_vec)
+            (plane_normal, plane_normal)
         }
     };
 
@@ -221,7 +213,9 @@ pub fn drag_transform_gizmo(
             axis_normalized * snapped_distance
         }
         TransformGizmo::Plane => {
-            let projected = active_axis * raw_delta;
+            let plane_normal_normalized = normal.normalize_or_zero();
+            let normal_component = raw_delta.dot(plane_normal_normalized);
+            let projected = raw_delta - (plane_normal_normalized * normal_component);
             snap_gizmo(projected, gizmo_snap.transform_value)
         }
     };

--- a/crates/bevy_granite_gizmos/src/gizmos/transform/drag.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/transform/drag.rs
@@ -1,6 +1,6 @@
 use super::TransformGizmo;
 use crate::{
-    gizmos::{GizmoOf, GizmoSnap},
+    gizmos::{GizmoConfig, GizmoOf, GizmoRoot, GizmoSnap, GizmoMode},
     input::GizmoAxis,
     selection::{ActiveSelection, RequestDuplicateAllSelectionEvent, Selected},
     GizmoCamera,
@@ -13,7 +13,7 @@ use bevy::{
     gizmos::{retained::Gizmo, GizmoAsset},
     picking::events::{Drag, DragEnd, DragStart, Pointer, Press},
     prelude::{
-        Entity, GlobalTransform, Query, Res, ResMut, Resource, Transform, Vec3, With, Without,
+        Entity, GlobalTransform, Query, Quat, Res, ResMut, Resource, Transform, Vec3, With, Without,
     },
 };
 use bevy_granite_core::UserInput;
@@ -38,7 +38,8 @@ pub fn drag_transform_gizmo(
     active_selection: Query<Entity, With<ActiveSelection>>,
     other_selected: Query<Entity, (With<Selected>, Without<ActiveSelection>)>,
     gizmo_snap: Res<GizmoSnap>,
-    gizmo_data: Query<(&GizmoAxis, &TransformGizmo, &InitialDragOffset)>,
+    gizmo_data: Query<(&GizmoAxis, &TransformGizmo, &InitialDragOffset, &GizmoRoot)>,
+    gizmo_config_query: Query<&GizmoConfig>,
     user_input: Res<UserInput>,
     mut duplication_state: ResMut<TransformDuplicationState>,
 ) {
@@ -50,13 +51,24 @@ pub fn drag_transform_gizmo(
         duplication_state.just_duplicated = false;
         return;
     }
-    let Ok((axis, typ, drag_offset)) = gizmo_data.get(event.entity) else {
+    let Ok((axis, typ, drag_offset, gizmo_root)) = gizmo_data.get(event.entity) else {
         log!(
             LogType::Editor,
             LogLevel::Warning,
             LogCategory::Input,
             "Gizmo Axis data not found for Gizmo entity {:?}",
             event.entity
+        );
+        return;
+    };
+    
+    let Ok(gizmo_config) = gizmo_config_query.get(gizmo_root.0) else {
+        log!(
+            LogType::Editor,
+            LogLevel::Warning,
+            LogCategory::Input,
+            "Gizmo config not found for parent gizmo entity {:?}",
+            gizmo_root.0
         );
         return;
     };
@@ -140,9 +152,47 @@ pub fn drag_transform_gizmo(
         }
     };
 
+    let target_rotation = if let Ok(global_transform) = global_transforms.get(*target) {
+        global_transform.to_scale_rotation_translation().1
+    } else {
+        if let Ok(transform) = objects.get(*target) {
+            transform.rotation
+        } else {
+            Quat::IDENTITY
+        }
+    };
+
     let (active_axis, normal) = match typ {
-        TransformGizmo::Axis => (axis.to_vec3(), camera_transform.forward().as_vec3()),
-        TransformGizmo::Plane => (axis.plane_as_vec3(), axis.to_vec3()),
+        TransformGizmo::Axis => {
+            let axis_vec = match gizmo_config.mode() {
+                GizmoMode::Local => {
+                    target_rotation * axis.to_vec3()
+                }
+                GizmoMode::Global => {
+                    axis.to_vec3()
+                }
+            };
+            (axis_vec, camera_transform.forward().as_vec3())
+        }
+        TransformGizmo::Plane => {
+            let plane_vec = match gizmo_config.mode() {
+                GizmoMode::Local => {
+                    target_rotation * axis.to_vec3()
+                }
+                GizmoMode::Global => {
+                    axis.to_vec3()
+                }
+            };
+            let active_vec = match gizmo_config.mode() {
+                GizmoMode::Local => {
+                    target_rotation * axis.plane_as_vec3()
+                }
+                GizmoMode::Global => {
+                    axis.plane_as_vec3()
+                }
+            };
+            (active_vec, plane_vec)
+        }
     };
 
     current_world_pos -= drag_offset.offset();
@@ -156,9 +206,28 @@ pub fn drag_transform_gizmo(
 
     let hit = click_ray.get_point(click_distance);
     let raw_delta = hit - current_world_pos;
-    let mut world_delta = snap_gizmo(active_axis * raw_delta, gizmo_snap.transform_value);
-
+    
+    let world_delta = match typ {
+        TransformGizmo::Axis => {
+            let axis_normalized = active_axis.normalize_or_zero();
+            let projection = raw_delta.dot(axis_normalized);
+            
+            let snapped_distance = if gizmo_snap.transform_value == 0.0 {
+                projection
+            } else {
+                (projection / gizmo_snap.transform_value).round() * gizmo_snap.transform_value
+            };
+            
+            axis_normalized * snapped_distance
+        }
+        TransformGizmo::Plane => {
+            let projected = active_axis * raw_delta;
+            snap_gizmo(projected, gizmo_snap.transform_value)
+        }
+    };
+    
     // Apply the delta to all root selected entities
+    let mut world_delta = world_delta;
     if world_delta.length() > 0.0 {
         for &entity in &root_entities {
             if let Ok(parent) = parents.get(entity) {
@@ -272,7 +341,8 @@ fn snap_gizmo(value: Vec3, inc: f32) -> Vec3 {
 
 pub fn draw_axis_lines(
     event: On<Pointer<Press>>,
-    gizmo_data: Query<(&GizmoAxis, &GizmoOf, &TransformGizmo), With<TransformGizmo>>,
+    gizmo_data: Query<(&GizmoAxis, &GizmoOf, &TransformGizmo, &GizmoRoot), With<TransformGizmo>>,
+    gizmo_config_query: Query<&GizmoConfig>,
     mut bevy_gizmo: ResMut<Assets<GizmoAsset>>,
     mut commands: Commands,
     origin: Query<&GlobalTransform>,
@@ -281,12 +351,24 @@ pub fn draw_axis_lines(
         return;
     }
 
-    let Ok((axis, root, transform)) = gizmo_data.get(event.entity) else {
+    let Ok((axis, root, transform, gizmo_root)) = gizmo_data.get(event.entity) else {
         return;
     };
     if let GizmoAxis::All = axis {
         return;
     }
+    
+    let Ok(gizmo_config) = gizmo_config_query.get(gizmo_root.0) else {
+        log! {
+            LogType::Editor,
+            LogLevel::Warning,
+            LogCategory::Input,
+            "Gizmo config not found for parent gizmo entity {:?}",
+            gizmo_root.0
+        };
+        return;
+    };
+    
     let Ok(origin) = origin.get(root.get()) else {
         log! {
             LogType::Editor,
@@ -297,15 +379,18 @@ pub fn draw_axis_lines(
         };
         return;
     };
+    
+    let entity_rotation = origin.to_scale_rotation_translation().1;
+    
     let mut asset = GizmoAsset::new();
     match transform {
         TransformGizmo::Axis => {
-            render_line(&mut asset, axis, origin);
+            render_line(&mut asset, axis, origin, entity_rotation, gizmo_config.mode());
         }
         TransformGizmo::Plane => {
             let (a, b) = axis.plane();
-            render_line(&mut asset, &a, origin);
-            render_line(&mut asset, &b, origin);
+            render_line(&mut asset, &a, origin, entity_rotation, gizmo_config.mode());
+            render_line(&mut asset, &b, origin, entity_rotation, gizmo_config.mode());
         }
     }
 
@@ -320,16 +405,30 @@ pub fn draw_axis_lines(
     ));
 }
 
-// Fix for too thick of lines
-// Thanks to 0xD21F
-fn render_line(asset: &mut GizmoAsset, axis: &GizmoAxis, origin: &GlobalTransform) {
+fn render_line(
+    asset: &mut GizmoAsset, 
+    axis: &GizmoAxis, 
+    origin: &GlobalTransform,
+    entity_rotation: Quat,
+    mode: GizmoMode,
+) {
     let step = 10.0;
     let max_distance = 1000.0;
     let mut current = -max_distance;
+    
+    let axis_direction = match mode {
+        GizmoMode::Local => {
+            entity_rotation * axis.to_vec3()
+        }
+        GizmoMode::Global => {
+            axis.to_vec3()
+        }
+    };
+    
     while current < max_distance {
         asset.line(
-            origin.translation() + axis.to_vec3() * current,
-            origin.translation() + axis.to_vec3() * (current + step),
+            origin.translation() + axis_direction * current,
+            origin.translation() + axis_direction * (current + step),
             axis.color(),
         );
         current += step;

--- a/crates/bevy_granite_gizmos/src/gizmos/transform/gizmo.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/transform/gizmo.rs
@@ -6,7 +6,7 @@ use bevy::{
     prelude::{
         AlphaMode, Assets, Color, Commands, Component, Cone, Cylinder, Entity, GlobalTransform,
         Mesh, Meshable, Name, Quat, Query, ResMut, Resource, Sphere, StandardMaterial, Transform,
-        Vec3, Visibility, Without,
+        Vec3, Visibility, With, Without,
     },
 };
 use bevy_granite_core::TreeHiddenEntity;
@@ -16,7 +16,7 @@ use bevy_granite_logging::{
 };
 
 use crate::{
-    gizmos::{GizmoConfig, GizmoMesh, GizmoOf, GizmoRoot},
+    gizmos::{GizmoConfig, GizmoMesh, GizmoMode, GizmoOf, GizmoRoot},
     input::GizmoAxis,
 };
 
@@ -341,5 +341,25 @@ fn plane_rotation(axis: GizmoAxis) -> Quat {
         GizmoAxis::Y => Quat::IDENTITY,
         GizmoAxis::Z => Quat::from_rotation_x(std::f32::consts::FRAC_PI_2),
         _ => Quat::IDENTITY,
+    }
+}
+
+pub fn update_gizmo_rotation_for_mode(
+    mut gizmo_query: Query<(&mut Transform, &GizmoOf, &GizmoConfig), With<TransformGizmoParent>>,
+    parent_query: Query<&GlobalTransform>,
+) {
+    for (mut gizmo_transform, gizmo_of, config) in gizmo_query.iter_mut() {
+        if let Ok(parent_global_transform) = parent_query.get(gizmo_of.0) {
+            let parent_rotation = parent_global_transform.to_scale_rotation_translation().1;
+            
+            match config.mode() {
+                GizmoMode::Global => {
+                    gizmo_transform.rotation = parent_rotation.inverse();
+                }
+                GizmoMode::Local => {
+                    gizmo_transform.rotation = Quat::IDENTITY;
+                }
+            }
+        }
     }
 }

--- a/crates/bevy_granite_gizmos/src/input/drag.rs
+++ b/crates/bevy_granite_gizmos/src/input/drag.rs
@@ -1,14 +1,16 @@
 use bevy::{
     color::Color,
-    ecs::{component::Component, resource::Resource},
+    ecs::{component::Component, resource::Resource, entity::Entity},
     math::{bool, Quat, Vec2, Vec3},
 };
+use std::collections::HashMap;
 
 #[derive(Resource, Component, PartialEq, Clone)]
 pub struct DragState {
     pub dragging: bool,
     pub raycast_position: Vec3,
     pub initial_cursor_position: Vec2,
+    pub previous_cursor_position: Vec2,
     pub initial_selection_rotation: Quat,
     pub gizmo_position: Vec3,
     pub initial_gizmo_rotation: Quat,
@@ -17,6 +19,9 @@ pub struct DragState {
     pub accumulated_angle: f32,
     pub last_snapped: f32,
     pub prev_hit_dir: Vec3,
+    pub initial_hit_angle: f32,
+    pub initial_entity_rotations: HashMap<Entity, Quat>,
+    pub first_drag_frame: bool,
 }
 
 impl Default for DragState {
@@ -25,6 +30,7 @@ impl Default for DragState {
             dragging: false,
             raycast_position: Vec3::ZERO,
             initial_cursor_position: Vec2::ZERO,
+            previous_cursor_position: Vec2::ZERO,
             initial_gizmo_rotation: Quat::default(),
             gizmo_position: Vec3::ZERO,
             initial_selection_rotation: Quat::default(),
@@ -33,6 +39,9 @@ impl Default for DragState {
             accumulated_angle: 0.,
             last_snapped: 0.,
             prev_hit_dir: Vec3::NAN,
+            initial_hit_angle: 0.0,
+            initial_entity_rotations: HashMap::new(),
+            first_drag_frame: true,
         }
     }
 }

--- a/crates/bevy_granite_gizmos/src/input/drag.rs
+++ b/crates/bevy_granite_gizmos/src/input/drag.rs
@@ -1,16 +1,14 @@
 use bevy::{
     color::Color,
-    ecs::{component::Component, resource::Resource, entity::Entity},
+    ecs::{component::Component, resource::Resource},
     math::{bool, Quat, Vec2, Vec3},
 };
-use std::collections::HashMap;
 
 #[derive(Resource, Component, PartialEq, Clone)]
 pub struct DragState {
     pub dragging: bool,
     pub raycast_position: Vec3,
     pub initial_cursor_position: Vec2,
-    pub previous_cursor_position: Vec2,
     pub initial_selection_rotation: Quat,
     pub gizmo_position: Vec3,
     pub initial_gizmo_rotation: Quat,
@@ -19,9 +17,6 @@ pub struct DragState {
     pub accumulated_angle: f32,
     pub last_snapped: f32,
     pub prev_hit_dir: Vec3,
-    pub initial_hit_angle: f32,
-    pub initial_entity_rotations: HashMap<Entity, Quat>,
-    pub first_drag_frame: bool,
 }
 
 impl Default for DragState {
@@ -30,7 +25,6 @@ impl Default for DragState {
             dragging: false,
             raycast_position: Vec3::ZERO,
             initial_cursor_position: Vec2::ZERO,
-            previous_cursor_position: Vec2::ZERO,
             initial_gizmo_rotation: Quat::default(),
             gizmo_position: Vec3::ZERO,
             initial_selection_rotation: Quat::default(),
@@ -39,9 +33,6 @@ impl Default for DragState {
             accumulated_angle: 0.,
             last_snapped: 0.,
             prev_hit_dir: Vec3::NAN,
-            initial_hit_angle: 0.0,
-            initial_entity_rotations: HashMap::new(),
-            first_drag_frame: true,
         }
     }
 }

--- a/crates/bevy_granite_gizmos/src/ui/panel.rs
+++ b/crates/bevy_granite_gizmos/src/ui/panel.rs
@@ -121,6 +121,7 @@ pub fn editor_gizmos_ui(
                         };
                         gizmo.set_type(active, &config);
                         gizmo.set_mode(mode);
+                        config.mode = mode; 
                         **selected_option = active;
                     } else {
                         config.mode = mode;


### PR DESCRIPTION
- Added support for local or global gizmo manipulation for both rotate and transform
- Persist local/global mode between gizmo swaps
- Cleaned up the locked axis rotate gizmo to be angular instead of relying on mouse delta. Screen pixels were causing issues from different angles
- Cleaned up rotate gizmo propagation so we aren't behind a frame and it visually stays in the same spot
- Closes #68 

https://github.com/user-attachments/assets/4203e602-1cfa-4b8d-92ad-3fcc30284b80

