### PR TITLE
Persist resized side and bottom panel dimensions

### DIFF
--- a/crates/bevy_granite_editor/src/editor_state/dock.rs
+++ b/crates/bevy_granite_editor/src/editor_state/dock.rs
@@ -22,7 +22,9 @@ use toml::{from_str, to_string};
 #[derive(Default, Clone, Serialize, Deserialize, PartialEq, Debug)]
 pub struct DockLayoutStr {
     pub right_dock_state: Option<String>,
+    pub right_dock_width: Option<f32>,
     pub bottom_dock_state: Option<String>,
+    pub bottom_dock_height: Option<f32>,
 }
 
 pub fn save_dock_on_window_close_system(
@@ -45,11 +47,15 @@ pub fn get_dock_state_str(
     bottom_dock_state: BottomDockState,
 ) -> DockLayoutStr {
     let right_tree = to_string(&right_dock_state.dock_state).unwrap();
+    let right_width = right_dock_state.width;
     let bottom_tree = to_string(&bottom_dock_state.dock_state).unwrap();
+    let bottom_height = bottom_dock_state.height;
 
     DockLayoutStr {
         right_dock_state: Some(right_tree),
+        right_dock_width: right_width,
         bottom_dock_state: Some(bottom_tree),
+        bottom_dock_height: bottom_height,
     }
 }
 
@@ -64,11 +70,16 @@ pub fn load_dock_state(
         }
     }
 
+    right_dock_state.width = dock_layout.right_dock_width;
+
     if let Some(ref bottom_tree) = dock_layout.bottom_dock_state {
         if let Ok(dock_state) = from_str(bottom_tree) {
             bottom_dock_state.dock_state = dock_state;
         }
     }
+
+    bottom_dock_state.height = dock_layout.bottom_dock_height;
+
     log!(
         LogType::Editor,
         LogLevel::OK,

--- a/crates/bevy_granite_editor/src/interface/panels/bottom_panel.rs
+++ b/crates/bevy_granite_editor/src/interface/panels/bottom_panel.rs
@@ -10,6 +10,7 @@ use crate::interface::tabs::{
 #[derive(Resource, Clone)]
 pub struct BottomDockState {
     pub dock_state: DockState<BottomTab>,
+    pub height: Option<f32>,
 }
 
 impl Default for BottomDockState {
@@ -32,7 +33,7 @@ impl Default for BottomDockState {
             surface.split_right(NodeIndex::root(), 0.33, vec![events_tab]);
         let [_events_node, _log_node] = surface.split_right(remaining, 0.5, vec![log_tab]);
 
-        Self { dock_state }
+        Self { dock_state, height: None }
     }
 }
 

--- a/crates/bevy_granite_editor/src/interface/panels/right_panel.rs
+++ b/crates/bevy_granite_editor/src/interface/panels/right_panel.rs
@@ -14,6 +14,7 @@ use crate::interface::{
 #[derive(Resource, Clone)]
 pub struct SideDockState {
     pub dock_state: DockState<SideTab>,
+    pub width: Option<f32>,
 }
 
 impl Default for SideDockState {
@@ -33,7 +34,7 @@ impl Default for SideDockState {
         let [_old_node, _entity_editor_node] =
             surface.split_below(NodeIndex::root(), 0.3, vec![entity_editor_tab]);
 
-        Self { dock_state }
+        Self { dock_state, width: None }
     }
 }
 


### PR DESCRIPTION
Currently, the side and bottom panels are created with a default size every time the editor loads, while the position of docks etc. is persisted in the editor config. To make the editor experience more consistent, this PR makes it so that the side panel width and bottom panel height as well.