### PR TITLE
Panels toggleable

### DIFF
--- a/crates/bevy_granite_editor/src/editor_state/dock.rs
+++ b/crates/bevy_granite_editor/src/editor_state/dock.rs
@@ -22,7 +22,9 @@ use toml::{from_str, to_string};
 #[derive(Default, Clone, Serialize, Deserialize, PartialEq, Debug)]
 pub struct DockLayoutStr {
     pub right_dock_state: Option<String>,
+    pub right_dock_width: Option<f32>,
     pub bottom_dock_state: Option<String>,
+    pub bottom_dock_height: Option<f32>,
 }
 
 pub fn save_dock_on_window_close_system(
@@ -45,11 +47,15 @@ pub fn get_dock_state_str(
     bottom_dock_state: BottomDockState,
 ) -> DockLayoutStr {
     let right_tree = to_string(&right_dock_state.dock_state).unwrap();
+    let right_width = right_dock_state.width;
     let bottom_tree = to_string(&bottom_dock_state.dock_state).unwrap();
+    let bottom_height = bottom_dock_state.height;
 
     DockLayoutStr {
         right_dock_state: Some(right_tree),
+        right_dock_width: right_width,
         bottom_dock_state: Some(bottom_tree),
+        bottom_dock_height: bottom_height,
     }
 }
 
@@ -64,11 +70,16 @@ pub fn load_dock_state(
         }
     }
 
+    right_dock_state.width = dock_layout.right_dock_width;
+
     if let Some(ref bottom_tree) = dock_layout.bottom_dock_state {
         if let Ok(dock_state) = from_str(bottom_tree) {
             bottom_dock_state.dock_state = dock_state;
         }
     }
+
+    bottom_dock_state.height = dock_layout.bottom_dock_height;
+
     log!(
         LogType::Editor,
         LogLevel::OK,

--- a/crates/bevy_granite_editor/src/interface/layout/top_bar.rs
+++ b/crates/bevy_granite_editor/src/interface/layout/top_bar.rs
@@ -6,8 +6,7 @@ use crate::{
             RequestToggleCameraSync, RequestViewportCameraOverride, SetActiveWorld,
         },
         panels::{
-            bottom_panel::{BottomDockState, BottomTab},
-            right_panel::{SideDockState, SideTab},
+            bottom_panel::{BottomDockState, BottomTab}, right_panel::{SideDockState, SideTab}, BottomTabType, SideTabType
         },
         popups::PopupType,
         tabs::{
@@ -177,89 +176,52 @@ pub fn top_bar_ui(
                     ui.close();
                 }
             });
+
             ui.menu_button("Panels", |ui| {
-                // Entity Editor
-                if !side_dock
-                    .dock_state
-                    .iter_all_tabs()
-                    .any(|(_, tab)| matches!(tab, SideTab::EntityEditor { .. }))
-                    && ui.button("EntityEditor").clicked()
-                {
-                    let tab = SideTab::EntityEditor {
-                        data: Box::new(EntityEditorTabData::default()),
-                    };
-                    side_dock.dock_state.push_to_focused_leaf(tab);
-                    ui.close();
+                for (tab_type, label) in vec![
+                    (SideTabType::EntityEditor, "Entity Editor"),
+                    (SideTabType::NodeTree, "Entities"),
+                    (SideTabType::EditorSettings, "Editor Settings"),
+                ] {
+                    let tab = side_dock.dock_state.find_tab_from(|tab| tab.get_type() == tab_type);
+                    let mut show = tab.is_some();
+                    let checkbox = ui.checkbox(&mut show, label);
+                    if checkbox.clicked() {
+                        match tab {
+                            Some(tab) => {
+                                side_dock.dock_state.remove_tab(tab);
+                            }
+                            None => {
+                                let tab = SideTab::default_from_type(tab_type);
+                                side_dock.dock_state.push_to_focused_leaf(tab);
+                            }
+                        }
+                        ui.close();
+                    }
                 }
 
-                // Node tree
-                if !side_dock
-                    .dock_state
-                    .iter_all_tabs()
-                    .any(|(_, tab)| matches!(tab, SideTab::NodeTree { .. }))
-                    && ui.button("Entities").clicked()
-                {
-                    let tab = SideTab::NodeTree {
-                        data: Box::new(NodeTreeTabData::default()),
-                    };
-                    side_dock.dock_state.push_to_focused_leaf(tab);
-                    ui.close();
-                }
+                ui.separator();
 
-                // Settings
-                if !side_dock
-                    .dock_state
-                    .iter_all_tabs()
-                    .any(|(_, tab)| matches!(tab, SideTab::EditorSettings { .. }))
-                    && ui.button("Editor Settings").clicked()
-                {
-                    let tab = SideTab::EditorSettings {
-                        data: Box::new(EditorSettingsTabData::default()),
-                    };
-                    side_dock.dock_state.push_to_focused_leaf(tab);
-                    ui.close();
-                }
-
-                // Log
-                if !bottom_dock
-                    .dock_state
-                    .iter_all_tabs()
-                    .any(|(_, tab)| matches!(tab, BottomTab::Log { .. }))
-                    && ui.button("Log").clicked()
-                {
-                    let tab = BottomTab::Log {
-                        data: LogTabData::default(),
-                    };
-                    bottom_dock.dock_state.push_to_focused_leaf(tab);
-                    ui.close();
-                }
-
-                // Debug
-                if !bottom_dock
-                    .dock_state
-                    .iter_all_tabs()
-                    .any(|(_, tab)| matches!(tab, BottomTab::Debug { .. }))
-                    && ui.button("Debug").clicked()
-                {
-                    let tab = BottomTab::Debug {
-                        data: DebugTabData::default(),
-                    };
-                    bottom_dock.dock_state.push_to_focused_leaf(tab);
-                    ui.close();
-                }
-
-                // Event
-                if !bottom_dock
-                    .dock_state
-                    .iter_all_tabs()
-                    .any(|(_, tab)| matches!(tab, BottomTab::Events { .. }))
-                    && ui.button("Events").clicked()
-                {
-                    let tab = BottomTab::Events {
-                        data: EventsTabData::default(),
-                    };
-                    bottom_dock.dock_state.push_to_focused_leaf(tab);
-                    ui.close();
+                for (tab_type, label) in vec![
+                    (BottomTabType::Log, "Log"),
+                    (BottomTabType::Debug, "Debug"),
+                    (BottomTabType::Events, "Events"),
+                ] {
+                    let tab = bottom_dock.dock_state.find_tab_from(|tab| tab.get_type() == tab_type);
+                    let mut show = tab.is_some();
+                    let checkbox = ui.checkbox(&mut show, label);
+                    if checkbox.clicked() {
+                        match tab {
+                            Some(tab) => {
+                                bottom_dock.dock_state.remove_tab(tab);
+                            }
+                            None => {
+                                let tab = BottomTab::default_from_type(tab_type);
+                                bottom_dock.dock_state.push_to_focused_leaf(tab);
+                            }
+                        }
+                        ui.close();
+                    }
                 }
             });
         });

--- a/crates/bevy_granite_editor/src/interface/panels/bottom_panel.rs
+++ b/crates/bevy_granite_editor/src/interface/panels/bottom_panel.rs
@@ -37,6 +37,13 @@ impl Default for BottomDockState {
     }
 }
 
+#[derive(PartialEq)]
+pub enum BottomTabType {
+    Log,
+    Debug,
+    Events,
+}
+
 #[derive(Clone, PartialEq, Serialize, Deserialize)]
 pub enum BottomTab {
     Log {
@@ -53,6 +60,29 @@ pub enum BottomTab {
     },
 }
 
+impl BottomTab {
+    pub fn get_type(&self) -> BottomTabType {
+        match self {
+            BottomTab::Log { .. } => BottomTabType::Log,
+            BottomTab::Debug { .. } => BottomTabType::Debug,
+            BottomTab::Events { .. } => BottomTabType::Events,
+        }
+    }
+
+    pub fn default_from_type(tab_type: BottomTabType) -> Self {
+        match tab_type {
+            BottomTabType::Log => BottomTab::Log {
+                data: Default::default(),
+            },
+            BottomTabType::Debug => BottomTab::Debug {
+                data: Default::default(),
+            },
+            BottomTabType::Events => BottomTab::Events {
+                data: Default::default(),
+            },
+        }
+    }
+}
 #[derive(Resource)]
 pub struct BottomTabViewer;
 

--- a/crates/bevy_granite_editor/src/interface/panels/bottom_panel.rs
+++ b/crates/bevy_granite_editor/src/interface/panels/bottom_panel.rs
@@ -10,6 +10,7 @@ use crate::interface::tabs::{
 #[derive(Resource, Clone)]
 pub struct BottomDockState {
     pub dock_state: DockState<BottomTab>,
+    pub height: Option<f32>,
 }
 
 impl Default for BottomDockState {
@@ -32,7 +33,7 @@ impl Default for BottomDockState {
             surface.split_right(NodeIndex::root(), 0.33, vec![events_tab]);
         let [_events_node, _log_node] = surface.split_right(remaining, 0.5, vec![log_tab]);
 
-        Self { dock_state }
+        Self { dock_state, height: None }
     }
 }
 

--- a/crates/bevy_granite_editor/src/interface/panels/right_panel.rs
+++ b/crates/bevy_granite_editor/src/interface/panels/right_panel.rs
@@ -38,6 +38,13 @@ impl Default for SideDockState {
     }
 }
 
+#[derive(PartialEq)]
+pub enum SideTabType {
+    EntityEditor,
+    NodeTree,
+    EditorSettings,
+}
+
 #[derive(Clone, PartialEq, Serialize, Deserialize)]
 pub enum SideTab {
     EntityEditor {
@@ -52,6 +59,30 @@ pub enum SideTab {
         #[serde(skip)]
         data: Box<EditorSettingsTabData>,
     },
+}
+
+impl SideTab {
+    pub fn get_type(&self) -> SideTabType {
+        match self {
+            SideTab::EntityEditor { .. } => SideTabType::EntityEditor,
+            SideTab::NodeTree { .. } => SideTabType::NodeTree,
+            SideTab::EditorSettings { .. } => SideTabType::EditorSettings,
+        }
+    }
+
+    pub fn default_from_type(tab_type: SideTabType) -> Self {
+        match tab_type {
+            SideTabType::EntityEditor => SideTab::EntityEditor {
+                data: Box::default(),
+            },
+            SideTabType::NodeTree => SideTab::NodeTree {
+                data: Box::default(),
+            },
+            SideTabType::EditorSettings => SideTab::EditorSettings {
+                data: Box::default(),
+            },
+        }
+    }
 }
 
 #[derive(Resource)]

--- a/crates/bevy_granite_editor/src/interface/panels/right_panel.rs
+++ b/crates/bevy_granite_editor/src/interface/panels/right_panel.rs
@@ -14,6 +14,7 @@ use crate::interface::{
 #[derive(Resource, Clone)]
 pub struct SideDockState {
     pub dock_state: DockState<SideTab>,
+    pub width: Option<f32>,
 }
 
 impl Default for SideDockState {
@@ -33,7 +34,7 @@ impl Default for SideDockState {
         let [_old_node, _entity_editor_node] =
             surface.split_below(NodeIndex::root(), 0.3, vec![entity_editor_tab]);
 
-        Self { dock_state }
+        Self { dock_state, width: None }
     }
 }
 


### PR DESCRIPTION
Currently, in the Panels menu only buttons appear for the panels that are not currently visible. This creates a visual glitch that when the menu has been opened once with no items in, any subsequently added buttons have a very narrow width:
<img width="157" height="288" alt="5073 tmp" src="https://github.com/user-attachments/assets/3e4064fe-63da-42cc-b08b-3a7be618c479" />

To solve this and to make the UI more consistent with other programs where you can toggle panel visibility, this PR replaces the menu buttons with checkboxes.
<img width="223" height="217" alt="afbeelding" src="https://github.com/user-attachments/assets/07b7f984-fb18-476b-b561-4758baed1be6" />

This PR also adds a helper enum SideTabType and BottomTabType with a default_from_type method. This moves tab data instantiation logic out of the egui code.
