### PR TITLE
Feature: Vertex Visualizer Gizmo Mode

### DIFF
--- a/crates/bevy_granite_editor/Cargo.toml
+++ b/crates/bevy_granite_editor/Cargo.toml
@@ -14,6 +14,7 @@ serde = { workspace =  true}
 native-dialog = { workspace = true }
 ron = { workspace = true }
 lazy_static = { workspace = true }
+arboard = "3.4"
 
 bevy_granite_gizmos = { path = "../bevy_granite_gizmos"}
 bevy_granite_core = { path = "../bevy_granite_core"}

--- a/crates/bevy_granite_editor/src/interface/tabs/editor_settings/ui.rs
+++ b/crates/bevy_granite_editor/src/interface/tabs/editor_settings/ui.rs
@@ -308,7 +308,7 @@ fn build_debug_icons_section(ui: &mut egui::Ui, viewport: &mut ViewportState) {
                         ui,
                         "Icon Size:",
                         &mut vis.icon_size,
-                        0.1..=5.0,
+                        0.025..=5.0,
                         0.1,
                         1,
                         None,

--- a/crates/bevy_granite_editor/src/interface/tabs/entity_editor/widgets/transform_editor.rs
+++ b/crates/bevy_granite_editor/src/interface/tabs/entity_editor/widgets/transform_editor.rs
@@ -1,4 +1,6 @@
 use crate::interface::tabs::EntityEditorTabData;
+use arboard::Clipboard;
+use bevy::math::Affine3A;
 use bevy::prelude::{EulerRot, Quat, Vec3};
 use bevy_egui::egui;
 use bevy_granite_core::TransformData;
@@ -79,41 +81,69 @@ fn display_transform_data(ui: &mut egui::Ui, data: &mut EntityEditorTabData) {
     let btn_height = font_id.size + style.spacing.button_padding.y * 2.0;
     let drag_size = [60., btn_height];
 
-    egui::Grid::new("transform_grid")
-        .num_columns(3)
-        .spacing([large_spacing, small_spacing])
-        .striped(true)
-        .show(ui, |ui| {
-            ui.set_min_width(ui.available_width());
+    ui.vertical(|ui| {
+        egui::Grid::new("transform_grid")
+            .num_columns(3)
+            .spacing([large_spacing, small_spacing])
+            .striped(true)
+            .show(ui, |ui| {
+                ui.set_min_width(ui.available_width());
 
-            // Position
-            ui.vertical(|ui| {
-                display_position_ui(ui, pos, changed, drag_size);
-            });
-            ui.end_row();
+                // Position
+                ui.vertical(|ui| {
+                    display_position_ui(ui, pos, changed, drag_size);
+                });
+                ui.end_row();
 
-            // Rotation
-            ui.vertical(|ui| {
-                display_rotation_ui(
-                    ui,
-                    euler,
-                    euler_radians,
-                    quat_rot,
-                    last_synced_quat,
-                    changed,
-                    editing,
-                    gizmo_locked_axis,
-                    drag_size,
-                );
-            });
-            ui.end_row();
+                // Rotation
+                ui.vertical(|ui| {
+                    display_rotation_ui(
+                        ui,
+                        euler,
+                        euler_radians,
+                        quat_rot,
+                        last_synced_quat,
+                        changed,
+                        editing,
+                        gizmo_locked_axis,
+                        drag_size,
+                    );
+                });
+                ui.end_row();
 
-            // Scale
-            ui.vertical(|ui| {
-                display_scale_ui(ui, scale, changed, drag_size);
+                // Scale
+                ui.vertical(|ui| {
+                    display_scale_ui(ui, scale, changed, drag_size);
+                });
+                ui.end_row();
             });
-            ui.end_row();
-        });
+
+        // Paste Matrix button below the transform grid
+        ui.add_space(large_spacing);
+        if ui.button("Paste Matrix").clicked() {
+            if let Ok(mut clipboard) = Clipboard::new() {
+                if let Ok(text) = clipboard.get_text() {
+                    if let Some((new_pos, new_rot, new_scale)) = parse_matrix_from_string(&text) {
+                        *pos = new_pos;
+                        *quat_rot = new_rot;
+                        *scale = new_scale;
+
+                        // Update euler angles from the new quaternion
+                        let (x, y, z) = quat_rot.to_euler(EulerRot::YXZ);
+                        let degrees = [x, y, z].map(|r| r * 180.0 / PI);
+                        *euler = Vec3::new(degrees[1], degrees[0], degrees[2]); // YXZ -> XYZ
+                        *euler_radians = Vec3::new(
+                            euler.x * PI / 180.0,
+                            euler.y * PI / 180.0,
+                            euler.z * PI / 180.0,
+                        );
+                        *last_synced_quat = *quat_rot;
+                        *changed = true;
+                    }
+                }
+            }
+        }
+    });
 
     if !ui.input(|i| i.pointer.any_down()) {
         *editing = [false; 3];
@@ -180,6 +210,7 @@ fn display_rotation_ui(
                     ui_changed[i] = ui_changed[i] || response.changed();
                 }
 
+                ui.add_space(spacing);
                 let zero = ui.add_sized(drag_size, egui::Button::new("Reset"));
 
                 let is_editing = editing.iter().any(|&e| e);
@@ -321,6 +352,7 @@ fn display_position_ui(ui: &mut egui::Ui, pos: &mut Vec3, changed: &mut bool, dr
                     }
                 });
 
+                ui.add_space(spacing);
                 let zero = ui.add_sized(drag_size, egui::Button::new("Reset"));
 
                 if zero.clicked() {
@@ -406,6 +438,7 @@ fn display_scale_ui(ui: &mut egui::Ui, scale: &mut Vec3, changed: &mut bool, dra
                     }
                 });
 
+                ui.add_space(spacing);
                 let reset = ui.add_sized(drag_size, egui::Button::new("Reset"));
 
                 if reset.clicked() {
@@ -459,4 +492,64 @@ fn normalize_euler_visual(euler: Vec3) -> Vec3 {
         normalize_angle_visual(euler.y),
         normalize_angle_visual(euler.z),
     )
+}
+
+/// Parse a 4x4 transformation matrix from the clipboard format
+/// Expected format:
+/// [m00, m01, m02, 0.0]
+/// [m10, m11, m12, 0.0]
+/// [m20, m21, m22, 0.0]
+/// [tx,  ty,  tz,  1.0]
+fn parse_matrix_from_string(text: &str) -> Option<(Vec3, Quat, Vec3)> {
+    let lines: Vec<&str> = text.lines().collect();
+    if lines.len() != 4 {
+        return None;
+    }
+
+    let mut matrix_values: Vec<Vec<f32>> = Vec::new();
+
+    for line in lines {
+        // Remove brackets and split by comma
+        let cleaned = line.trim().trim_start_matches('[').trim_end_matches(']');
+        let values: Result<Vec<f32>, _> = cleaned
+            .split(',')
+            .map(|s| s.trim().parse::<f32>())
+            .collect();
+
+        let values = values.ok()?;
+        if values.len() != 4 {
+            return None;
+        }
+        matrix_values.push(values);
+    }
+
+    // Reconstruct the affine transform
+    let matrix3 = bevy::math::Mat3::from_cols(
+        bevy::math::Vec3::new(
+            matrix_values[0][0],
+            matrix_values[0][1],
+            matrix_values[0][2],
+        ),
+        bevy::math::Vec3::new(
+            matrix_values[1][0],
+            matrix_values[1][1],
+            matrix_values[1][2],
+        ),
+        bevy::math::Vec3::new(
+            matrix_values[2][0],
+            matrix_values[2][1],
+            matrix_values[2][2],
+        ),
+    );
+
+    let translation = bevy::math::Vec3::new(
+        matrix_values[3][0],
+        matrix_values[3][1],
+        matrix_values[3][2],
+    );
+
+    let affine = Affine3A::from_mat3_translation(matrix3, translation);
+    let (scale, rotation, position) = affine.to_scale_rotation_translation();
+
+    Some((position, rotation, scale))
 }

--- a/crates/bevy_granite_editor/src/interface/tabs/entity_editor/widgets/transform_editor.rs
+++ b/crates/bevy_granite_editor/src/interface/tabs/entity_editor/widgets/transform_editor.rs
@@ -70,6 +70,7 @@ fn display_transform_data(ui: &mut egui::Ui, data: &mut EntityEditorTabData) {
     let gizmo_locked_axis = transform.gizmo_axis;
     let large_spacing = crate::UI_CONFIG.large_spacing;
     let small_spacing = crate::UI_CONFIG.small_spacing;
+    let spacing = crate::UI_CONFIG.spacing;
     let style = ui.ctx().style().clone();
     let default_font_id = egui::FontId::default();
 
@@ -118,31 +119,53 @@ fn display_transform_data(ui: &mut egui::Ui, data: &mut EntityEditorTabData) {
                 ui.end_row();
             });
 
-        // Paste Matrix button below the transform grid
+        // Copy and Paste Matrix buttons below the transform grid
         ui.add_space(large_spacing);
-        if ui.button("Paste Matrix").clicked() {
-            if let Ok(mut clipboard) = Clipboard::new() {
-                if let Ok(text) = clipboard.get_text() {
-                    if let Some((new_pos, new_rot, new_scale)) = parse_matrix_from_string(&text) {
-                        *pos = new_pos;
-                        *quat_rot = new_rot;
-                        *scale = new_scale;
+        ui.horizontal(|ui| {
+            if ui.button("Copy").clicked() {
+                let affine = Affine3A::from_scale_rotation_translation(*scale, *quat_rot, *pos);
+                let matrix = affine.matrix3;
+                let translation = affine.translation;
+                let matrix_text =
+                    format!(
+                    "[{}, {}, {}, 0.0]\n[{}, {}, {}, 0.0]\n[{}, {}, {}, 0.0]\n[{}, {}, {}, 1.0]",
+                    matrix.x_axis.x, matrix.x_axis.y, matrix.x_axis.z,
+                    matrix.y_axis.x, matrix.y_axis.y, matrix.y_axis.z,
+                    matrix.z_axis.x, matrix.z_axis.y, matrix.z_axis.z,
+                    translation.x, translation.y, translation.z,
+                );
 
-                        // Update euler angles from the new quaternion
-                        let (x, y, z) = quat_rot.to_euler(EulerRot::YXZ);
-                        let degrees = [x, y, z].map(|r| r * 180.0 / PI);
-                        *euler = Vec3::new(degrees[1], degrees[0], degrees[2]); // YXZ -> XYZ
-                        *euler_radians = Vec3::new(
-                            euler.x * PI / 180.0,
-                            euler.y * PI / 180.0,
-                            euler.z * PI / 180.0,
-                        );
-                        *last_synced_quat = *quat_rot;
-                        *changed = true;
+                if let Ok(mut clipboard) = Clipboard::new() {
+                    let _ = clipboard.set_text(matrix_text);
+                }
+            }
+
+            ui.add_space(spacing);
+            if ui.button("Paste").clicked() {
+                if let Ok(mut clipboard) = Clipboard::new() {
+                    if let Ok(text) = clipboard.get_text() {
+                        if let Some((new_pos, new_rot, new_scale)) = parse_matrix_from_string(&text)
+                        {
+                            *pos = new_pos;
+                            *quat_rot = new_rot;
+                            *scale = new_scale;
+
+                            // Update euler angles from the new quaternion
+                            let (x, y, z) = quat_rot.to_euler(EulerRot::YXZ);
+                            let degrees = [x, y, z].map(|r| r * 180.0 / PI);
+                            *euler = Vec3::new(degrees[1], degrees[0], degrees[2]); // YXZ -> XYZ
+                            *euler_radians = Vec3::new(
+                                euler.x * PI / 180.0,
+                                euler.y * PI / 180.0,
+                                euler.z * PI / 180.0,
+                            );
+                            *last_synced_quat = *quat_rot;
+                            *changed = true;
+                        }
                     }
                 }
             }
-        }
+        });
     });
 
     if !ui.input(|i| i.pointer.any_down()) {

--- a/crates/bevy_granite_editor/src/viewport/camera/system.rs
+++ b/crates/bevy_granite_editor/src/viewport/camera/system.rs
@@ -710,7 +710,8 @@ pub fn mouse_button_iter(
             time,
             movement_speed,
         );
-    } else {
+    } else if !user_input.mouse_middle.pressed {
+        // Only handle zoom when not in FPS mode (right mouse) and not panning (middle mouse)
         handle_zoom(&mut query, &mut mouse_wheel_events, &mut target_pos);
     }
 }

--- a/crates/bevy_granite_editor/src/viewport/camera/utils.rs
+++ b/crates/bevy_granite_editor/src/viewport/camera/utils.rs
@@ -130,7 +130,7 @@ pub fn handle_movement(
 
     for event in mouse_wheel_events.read() {
         *movement_speed *= 1.1_f32.powf(event.y);
-        *movement_speed = movement_speed.clamp(base_movement_speed, 2000.0);
+        *movement_speed = movement_speed.clamp(0.1, 2000.0);
     }
 
     let rotation_sensitivity = base_rotation_sensitivity;

--- a/crates/bevy_granite_gizmos/src/gizmos/distance_scaling.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/distance_scaling.rs
@@ -51,10 +51,11 @@ pub fn scale_gizmo_by_camera_distance_system(
             .translation()
             .distance(gizmo_global_transform.translation());
 
-        let base_scale = 0.35; // scale of gizmo's initially
-        let distance_scale = 0.08; // factor to scale via distance
-        let scale_factor = (distance * distance_scale).clamp(base_scale, 9.0); // 9.0 is max size of gizmo
-        let final_scale = (base_scale * scale_factor).clamp(base_scale, f32::INFINITY);
+        let base_scale = 0.5; 
+        let distance_scale = 0.08; 
+        let min_scale = 0.01; 
+        let scale_factor = (distance * distance_scale).clamp(min_scale, 9.0); 
+        let final_scale = (base_scale * scale_factor).clamp(min_scale, f32::INFINITY);
 
         // Apply the final scale while accounting for parent transforms
         gizmo_transform.scale = baseline_local_scale * final_scale;

--- a/crates/bevy_granite_gizmos/src/gizmos/manager.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/manager.rs
@@ -65,12 +65,12 @@ pub fn gizmo_changed_watcher(
     active_selection: Query<Entity, With<ActiveSelection>>,
 ) {
     if **selected_gizmo != last_selected_gizmo.value {
-        log!(
-            LogType::Editor,
-            LogLevel::OK,
-            LogCategory::Entity,
-            "Gizmo changed"
-        );
+        //log!(
+       //     LogType::Editor,
+        //    LogLevel::OK,
+        //    LogCategory::Entity,
+        //    "Gizmo changed"
+        //);
         despawn_writer.write(DespawnGizmoEvent(last_selected_gizmo.value));
         last_selected_gizmo.value = **selected_gizmo;
 

--- a/crates/bevy_granite_gizmos/src/gizmos/mod.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/mod.rs
@@ -10,6 +10,7 @@ pub mod manager;
 pub mod plugin;
 pub mod rotate;
 pub mod transform;
+pub mod vertex;
 
 #[derive(Clone, Default, Debug, Copy, PartialEq)]
 pub enum GizmoType {

--- a/crates/bevy_granite_gizmos/src/gizmos/vertex/components.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/vertex/components.rs
@@ -1,6 +1,5 @@
 use bevy::prelude::{Component, Entity, Vec3};
 
-/// Marks a vertex visualization sphere
 #[derive(Component)]
 pub struct VertexMarker {
     pub parent_entity: Entity,
@@ -8,15 +7,12 @@ pub struct VertexMarker {
     pub local_position: Vec3,
 }
 
-/// Marks a vertex as selected
 #[derive(Component)]
 pub struct SelectedVertex;
 
-/// Marks an entity that has vertex visualizations spawned for it
 #[derive(Component)]
 pub struct HasVertexVisualizations;
 
-/// Parent entity that holds all vertex markers for one mesh
 #[derive(Component)]
 pub struct VertexVisualizationParent {
     pub source_entity: Entity,

--- a/crates/bevy_granite_gizmos/src/gizmos/vertex/components.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/vertex/components.rs
@@ -1,0 +1,23 @@
+use bevy::prelude::{Component, Entity, Vec3};
+
+/// Marks a vertex visualization sphere
+#[derive(Component)]
+pub struct VertexMarker {
+    pub parent_entity: Entity,
+    pub vertex_index: usize,
+    pub local_position: Vec3,
+}
+
+/// Marks a vertex as selected
+#[derive(Component)]
+pub struct SelectedVertex;
+
+/// Marks an entity that has vertex visualizations spawned for it
+#[derive(Component)]
+pub struct HasVertexVisualizations;
+
+/// Parent entity that holds all vertex markers for one mesh
+#[derive(Component)]
+pub struct VertexVisualizationParent {
+    pub source_entity: Entity,
+}

--- a/crates/bevy_granite_gizmos/src/gizmos/vertex/config.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/vertex/config.rs
@@ -1,0 +1,30 @@
+use bevy::prelude::{Color, Entity, Resource, Vec3};
+
+/// Global configuration for vertex visualization
+#[derive(Resource)]
+pub struct VertexVisualizationConfig {
+    pub enabled: bool,
+    pub vertex_size: f32,
+    pub unselected_color: Color,
+    pub selected_color: Color,
+    pub highlight_color: Color,
+}
+
+impl Default for VertexVisualizationConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            vertex_size: 0.0125, 
+            unselected_color: Color::srgba(0.7, 0.7, 0.7, 0.8),
+            selected_color: Color::srgba(1.0, 0.8, 0.0, 1.0), // Yellow/gold for selected
+            highlight_color: Color::srgba(0.9, 0.9, 0.9, 1.0),
+        }
+    }
+}
+
+/// Tracks current vertex selection state
+#[derive(Resource, Default)]
+pub struct VertexSelectionState {
+    pub selected_vertices: Vec<Entity>,
+    pub midpoint_world: Option<Vec3>,
+}

--- a/crates/bevy_granite_gizmos/src/gizmos/vertex/config.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/vertex/config.rs
@@ -1,6 +1,5 @@
 use bevy::prelude::{Color, Entity, Resource, Vec3};
 
-/// Global configuration for vertex visualization
 #[derive(Resource)]
 pub struct VertexVisualizationConfig {
     pub enabled: bool,
@@ -14,15 +13,14 @@ impl Default for VertexVisualizationConfig {
     fn default() -> Self {
         Self {
             enabled: false,
-            vertex_size: 0.008, 
+            vertex_size: 0.008,
             unselected_color: Color::srgba(0.7, 0.7, 0.7, 1.0),
-            selected_color: Color::srgba(1.0, 0.8, 0.0, 1.0), // Yellow/gold for selected
+            selected_color: Color::srgba(1.0, 0.8, 0.0, 1.0),
             highlight_color: Color::srgba(0.9, 0.9, 0.9, 1.0),
         }
     }
 }
 
-/// Tracks current vertex selection state
 #[derive(Resource, Default)]
 pub struct VertexSelectionState {
     pub selected_vertices: Vec<Entity>,

--- a/crates/bevy_granite_gizmos/src/gizmos/vertex/config.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/vertex/config.rs
@@ -14,8 +14,8 @@ impl Default for VertexVisualizationConfig {
     fn default() -> Self {
         Self {
             enabled: false,
-            vertex_size: 0.0125, 
-            unselected_color: Color::srgba(0.7, 0.7, 0.7, 0.8),
+            vertex_size: 0.008, 
+            unselected_color: Color::srgba(0.7, 0.7, 0.7, 1.0),
             selected_color: Color::srgba(1.0, 0.8, 0.0, 1.0), // Yellow/gold for selected
             highlight_color: Color::srgba(0.9, 0.9, 0.9, 1.0),
         }

--- a/crates/bevy_granite_gizmos/src/gizmos/vertex/interaction.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/vertex/interaction.rs
@@ -1,0 +1,120 @@
+use super::{
+    components::{SelectedVertex, VertexMarker},
+    config::{VertexSelectionState, VertexVisualizationConfig},
+};
+use bevy::{
+    ecs::observer::On,
+    pbr::MeshMaterial3d,
+    picking::events::{Click, Pointer},
+    prelude::{
+        Commands, Entity, KeyCode, Query, Res, ResMut, StandardMaterial, With, Without,
+    },
+};
+use bevy_granite_core::UserInput;
+use bevy_granite_logging::{
+    config::{LogCategory, LogLevel, LogType},
+    log,
+};
+
+/// System that handles clicking on vertices
+pub fn handle_vertex_click(
+    mut event: On<Pointer<Click>>,
+    mut commands: Commands,
+    user_input: Res<UserInput>,
+    vertex_query: Query<(Entity, &VertexMarker)>,
+    selected_vertices: Query<Entity, With<SelectedVertex>>,
+    mut selection_state: ResMut<VertexSelectionState>,
+) {
+    let clicked_entity = event.entity;
+
+    // Check if the clicked entity is a vertex marker
+    let Ok((vertex_entity, vertex_marker)) = vertex_query.get(clicked_entity) else {
+        return;
+    };
+
+    // Stop event propagation so other systems don't handle this click
+    event.propagate(false);
+
+    // Check if shift is held for additive selection
+    let is_additive = user_input
+        .current_button_inputs
+        .iter()
+        .any(|input| matches!(input, bevy_granite_core::InputTypes::Button(KeyCode::ShiftLeft | KeyCode::ShiftRight)));
+
+    if !is_additive {
+        // Clear all previously selected vertices
+        for entity in selected_vertices.iter() {
+            commands.entity(entity).remove::<SelectedVertex>();
+        }
+        selection_state.selected_vertices.clear();
+    }
+
+    // Select this vertex
+    commands.entity(vertex_entity).insert(SelectedVertex);
+    selection_state.selected_vertices.push(vertex_entity);
+
+    log!(
+        LogType::Editor,
+        LogLevel::Info,
+        LogCategory::Entity,
+        "Selected vertex {} on entity {:?}",
+        vertex_marker.vertex_index,
+        vertex_marker.parent_entity
+    );
+}
+
+/// System that updates vertex colors based on selection state
+pub fn update_vertex_colors(
+    config: Res<VertexVisualizationConfig>,
+    selected_vertices: Query<&MeshMaterial3d<StandardMaterial>, With<SelectedVertex>>,
+    unselected_vertices: Query<
+        &MeshMaterial3d<StandardMaterial>,
+        (With<VertexMarker>, Without<SelectedVertex>),
+    >,
+    mut materials: ResMut<bevy::prelude::Assets<StandardMaterial>>,
+) {
+    // Update selected vertices to selected color
+    for material_handle in selected_vertices.iter() {
+        if let Some(material) = materials.get_mut(&material_handle.0) {
+            material.base_color = config.selected_color;
+        }
+    }
+
+    // Update unselected vertices to default color
+    for material_handle in unselected_vertices.iter() {
+        if let Some(material) = materials.get_mut(&material_handle.0) {
+            material.base_color = config.unselected_color;
+        }
+    }
+}
+
+/// System to deselect all vertices (e.g., when clicking in empty space)
+pub fn deselect_all_vertices(
+    mut commands: Commands,
+    selected_vertices: Query<Entity, With<SelectedVertex>>,
+    mut selection_state: ResMut<VertexSelectionState>,
+    user_input: Res<UserInput>,
+) {
+    // Check for Escape key or other deselect conditions
+    let should_deselect = user_input
+        .current_button_inputs
+        .iter()
+        .any(|input| matches!(input, bevy_granite_core::InputTypes::Button(KeyCode::Escape)));
+
+    if should_deselect {
+        for entity in selected_vertices.iter() {
+            commands.entity(entity).remove::<SelectedVertex>();
+        }
+        selection_state.selected_vertices.clear();
+        selection_state.midpoint_world = None;
+
+        if !selected_vertices.is_empty() {
+            log!(
+                LogType::Editor,
+                LogLevel::Info,
+                LogCategory::Entity,
+                "Deselected all vertices"
+            );
+        }
+    }
+}

--- a/crates/bevy_granite_gizmos/src/gizmos/vertex/interaction.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/vertex/interaction.rs
@@ -6,9 +6,7 @@ use bevy::{
     ecs::observer::On,
     pbr::MeshMaterial3d,
     picking::events::{Click, Pointer},
-    prelude::{
-        Commands, Entity, KeyCode, Query, Res, ResMut, StandardMaterial, With, Without,
-    },
+    prelude::{Commands, Entity, KeyCode, Query, Res, ResMut, StandardMaterial, With, Without},
 };
 use bevy_granite_core::UserInput;
 use bevy_granite_logging::{
@@ -16,7 +14,6 @@ use bevy_granite_logging::{
     log,
 };
 
-/// System that handles clicking on vertices
 pub fn handle_vertex_click(
     mut event: On<Pointer<Click>>,
     mut commands: Commands,
@@ -27,29 +24,26 @@ pub fn handle_vertex_click(
 ) {
     let clicked_entity = event.entity;
 
-    // Check if the clicked entity is a vertex marker
     let Ok((vertex_entity, vertex_marker)) = vertex_query.get(clicked_entity) else {
         return;
     };
 
-    // Stop event propagation so other systems don't handle this click
     event.propagate(false);
 
-    // Check if shift is held for additive selection
-    let is_additive = user_input
-        .current_button_inputs
-        .iter()
-        .any(|input| matches!(input, bevy_granite_core::InputTypes::Button(KeyCode::ShiftLeft | KeyCode::ShiftRight)));
+    let is_additive = user_input.current_button_inputs.iter().any(|input| {
+        matches!(
+            input,
+            bevy_granite_core::InputTypes::Button(KeyCode::ShiftLeft | KeyCode::ShiftRight)
+        )
+    });
 
     if !is_additive {
-        // Clear all previously selected vertices
         for entity in selected_vertices.iter() {
             commands.entity(entity).remove::<SelectedVertex>();
         }
         selection_state.selected_vertices.clear();
     }
 
-    // Select this vertex
     commands.entity(vertex_entity).insert(SelectedVertex);
     selection_state.selected_vertices.push(vertex_entity);
 
@@ -63,7 +57,6 @@ pub fn handle_vertex_click(
     );
 }
 
-/// System that updates vertex colors based on selection state
 pub fn update_vertex_colors(
     config: Res<VertexVisualizationConfig>,
     selected_vertices: Query<&MeshMaterial3d<StandardMaterial>, With<SelectedVertex>>,
@@ -73,14 +66,12 @@ pub fn update_vertex_colors(
     >,
     mut materials: ResMut<bevy::prelude::Assets<StandardMaterial>>,
 ) {
-    // Update selected vertices to selected color
     for material_handle in selected_vertices.iter() {
         if let Some(material) = materials.get_mut(&material_handle.0) {
             material.base_color = config.selected_color;
         }
     }
 
-    // Update unselected vertices to default color
     for material_handle in unselected_vertices.iter() {
         if let Some(material) = materials.get_mut(&material_handle.0) {
             material.base_color = config.unselected_color;
@@ -88,18 +79,18 @@ pub fn update_vertex_colors(
     }
 }
 
-/// System to deselect all vertices (e.g., when clicking in empty space)
 pub fn deselect_all_vertices(
     mut commands: Commands,
     selected_vertices: Query<Entity, With<SelectedVertex>>,
     mut selection_state: ResMut<VertexSelectionState>,
     user_input: Res<UserInput>,
 ) {
-    // Check for Escape key or other deselect conditions
-    let should_deselect = user_input
-        .current_button_inputs
-        .iter()
-        .any(|input| matches!(input, bevy_granite_core::InputTypes::Button(KeyCode::Escape)));
+    let should_deselect = user_input.current_button_inputs.iter().any(|input| {
+        matches!(
+            input,
+            bevy_granite_core::InputTypes::Button(KeyCode::Escape)
+        )
+    });
 
     if should_deselect {
         for entity in selected_vertices.iter() {

--- a/crates/bevy_granite_gizmos/src/gizmos/vertex/midpoint.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/vertex/midpoint.rs
@@ -1,0 +1,31 @@
+use super::{
+    components::{SelectedVertex, VertexMarker},
+    config::VertexSelectionState,
+};
+use bevy::prelude::{GlobalTransform, Query, ResMut, Vec3, With};
+
+/// System that calculates the midpoint of all selected vertices
+pub fn calculate_vertex_midpoint(
+    mut selection_state: ResMut<VertexSelectionState>,
+    selected_vertices: Query<&GlobalTransform, (With<VertexMarker>, With<SelectedVertex>)>,
+) {
+    if selection_state.selected_vertices.len() < 2 {
+        selection_state.midpoint_world = None;
+        return;
+    }
+
+    let mut sum = Vec3::ZERO;
+    let mut count = 0;
+
+    for global_transform in selected_vertices.iter() {
+        sum += global_transform.translation();
+        count += 1;
+    }
+
+    if count > 0 {
+        let midpoint = sum / count as f32;
+        selection_state.midpoint_world = Some(midpoint);
+    } else {
+        selection_state.midpoint_world = None;
+    }
+}

--- a/crates/bevy_granite_gizmos/src/gizmos/vertex/midpoint.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/vertex/midpoint.rs
@@ -4,7 +4,6 @@ use super::{
 };
 use bevy::prelude::{GlobalTransform, Query, ResMut, Vec3, With};
 
-/// System that calculates the midpoint of all selected vertices
 pub fn calculate_vertex_midpoint(
     mut selection_state: ResMut<VertexSelectionState>,
     selected_vertices: Query<&GlobalTransform, (With<VertexMarker>, With<SelectedVertex>)>,

--- a/crates/bevy_granite_gizmos/src/gizmos/vertex/mod.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/vertex/mod.rs
@@ -5,7 +5,6 @@ pub mod midpoint;
 pub mod plugin;
 pub mod spawn;
 
-// Re-exports
 pub use components::{SelectedVertex, VertexMarker, VertexVisualizationParent};
 pub use config::{VertexSelectionState, VertexVisualizationConfig};
 pub use plugin::VertexVisualizationPlugin;

--- a/crates/bevy_granite_gizmos/src/gizmos/vertex/mod.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/vertex/mod.rs
@@ -1,0 +1,11 @@
+pub mod components;
+pub mod config;
+pub mod interaction;
+pub mod midpoint;
+pub mod plugin;
+pub mod spawn;
+
+// Re-exports
+pub use components::{SelectedVertex, VertexMarker, VertexVisualizationParent};
+pub use config::{VertexSelectionState, VertexVisualizationConfig};
+pub use plugin::VertexVisualizationPlugin;

--- a/crates/bevy_granite_gizmos/src/gizmos/vertex/plugin.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/vertex/plugin.rs
@@ -1,0 +1,37 @@
+use super::{
+    config::{VertexSelectionState, VertexVisualizationConfig},
+    interaction::{deselect_all_vertices, handle_vertex_click, update_vertex_colors},
+    midpoint::calculate_vertex_midpoint,
+    spawn::{
+        cleanup_deselected_entity_vertices, despawn_vertex_visualizations,
+        spawn_vertex_visualizations,
+    },
+};
+use crate::is_gizmos_active;
+use bevy::{app::{App, Plugin, Update}, ecs::schedule::IntoScheduleConfigs};
+
+pub struct VertexVisualizationPlugin;
+
+impl Plugin for VertexVisualizationPlugin {
+    fn build(&self, app: &mut App) {
+        app
+            // Resources
+            .insert_resource(VertexVisualizationConfig::default())
+            .insert_resource(VertexSelectionState::default())
+            // Systems
+            .add_systems(
+                Update,
+                (
+                    spawn_vertex_visualizations,
+                    despawn_vertex_visualizations,
+                    cleanup_deselected_entity_vertices,
+                    update_vertex_colors,
+                    deselect_all_vertices,
+                    calculate_vertex_midpoint,
+                )
+                    .run_if(is_gizmos_active),
+            )
+            // Observer for vertex clicks
+            .add_observer(handle_vertex_click);
+    }
+}

--- a/crates/bevy_granite_gizmos/src/gizmos/vertex/spawn.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/vertex/spawn.rs
@@ -7,6 +7,7 @@ use crate::{
     selection::Selected,
 };
 use bevy::{
+    camera::visibility::RenderLayers,
     ecs::hierarchy::ChildOf,
     light::{NotShadowCaster, NotShadowReceiver},
     mesh::{Mesh3d, VertexAttributeValues},
@@ -112,6 +113,7 @@ pub fn spawn_vertex_visualizations(
                 EditorIgnore::PICKING,
                 NotShadowCaster,
                 NotShadowReceiver,
+                RenderLayers::layer(14), // Layer 14 for gizmos - always renders on top
                 ChildOf(parent),
                 TreeHiddenEntity,
                 Name::new(format!("Vertex_{}", index)),

--- a/crates/bevy_granite_gizmos/src/gizmos/vertex/spawn.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/vertex/spawn.rs
@@ -31,18 +31,13 @@ pub fn spawn_vertex_visualizations(
     mut materials: ResMut<Assets<StandardMaterial>>,
     config: Res<VertexVisualizationConfig>,
     gizmo_type: Res<NewGizmoType>,
-    selected_entities: Query<
-        (Entity, &Mesh3d),
-        (With<Selected>, Without<HasVertexVisualizations>),
-    >,
+    selected_entities: Query<(Entity, &Mesh3d), (With<Selected>, Without<HasVertexVisualizations>)>,
 ) {
-    // Only spawn if in Pointer mode and enabled
     if !matches!(**gizmo_type, GizmoType::Pointer) || !config.enabled {
         return;
     }
 
     for (entity, mesh3d) in selected_entities.iter() {
-        // Get the mesh asset
         let Some(mesh) = meshes.get(&mesh3d.0) else {
             continue;
         };
@@ -84,15 +79,16 @@ pub fn spawn_vertex_visualizations(
 
         // Spawn a cube for each vertex
         for (index, position) in vertex_positions.iter().enumerate() {
-            let mesh_handle = meshes.add(Cuboid::new(config.vertex_size, config.vertex_size, config.vertex_size).mesh());
+            let mesh_handle = meshes.add(
+                Cuboid::new(config.vertex_size, config.vertex_size, config.vertex_size).mesh(),
+            );
 
             // Create a unique material for each vertex so they can be colored independently
-            // Disable depth write to make vertices visible through the mesh
             let material = materials.add(StandardMaterial {
                 base_color: config.unselected_color,
                 unlit: true,
                 alpha_mode: bevy::prelude::AlphaMode::Blend,
-                depth_bias: -0.1, // Negative bias helps with z-fighting
+                depth_bias: -0.1,
                 ..Default::default()
             });
 
@@ -120,8 +116,6 @@ pub fn spawn_vertex_visualizations(
             ));
         }
 
-        // Mark the entity as having vertex visualizations
-        // Use queue to defer the command and silently fail if entity doesn't exist
         commands
             .entity(entity)
             .queue_silenced(|mut entity: bevy::ecs::world::EntityWorldMut| {
@@ -144,7 +138,6 @@ pub fn despawn_vertex_visualizations(
 
     if should_despawn {
         for (parent_entity, viz_parent, children) in vertex_parents.iter() {
-            // Despawn all vertex marker children
             for child in children.iter() {
                 if let Ok(mut entity_commands) = commands.get_entity(*child) {
                     entity_commands.despawn();
@@ -154,7 +147,6 @@ pub fn despawn_vertex_visualizations(
             if let Ok(mut entity_commands) = commands.get_entity(parent_entity) {
                 entity_commands.despawn();
             }
-            // Remove the marker from the source entity
             commands
                 .entity(viz_parent.source_entity)
                 .remove::<HasVertexVisualizations>();
@@ -178,9 +170,7 @@ pub fn cleanup_deselected_entity_vertices(
     selected_entities: Query<Entity, With<Selected>>,
 ) {
     for (parent_entity, viz_parent, children) in vertex_parents.iter() {
-        // Check if the source entity is still selected
         if selected_entities.get(viz_parent.source_entity).is_err() {
-            // Entity is no longer selected, despawn its vertices
             for child in children.iter() {
                 if let Ok(mut entity_commands) = commands.get_entity(*child) {
                     entity_commands.despawn();
@@ -189,7 +179,6 @@ pub fn cleanup_deselected_entity_vertices(
             if let Ok(mut entity_commands) = commands.get_entity(parent_entity) {
                 entity_commands.despawn();
             }
-            // Remove the marker from the source entity
             commands
                 .entity(viz_parent.source_entity)
                 .remove::<HasVertexVisualizations>();
@@ -198,7 +187,6 @@ pub fn cleanup_deselected_entity_vertices(
 }
 
 /// Extract unique vertex positions from a mesh
-/// Deduplicates vertices that share the same position
 fn extract_vertex_positions(mesh: &Mesh) -> Option<Vec<Vec3>> {
     let positions = mesh.attribute(Mesh::ATTRIBUTE_POSITION)?;
 
@@ -209,7 +197,7 @@ fn extract_vertex_positions(mesh: &Mesh) -> Option<Vec<Vec3>> {
 
         for [x, y, z] in positions {
             let pos = Vec3::new(*x, *y, *z);
-            
+
             // Check if this position already exists (within epsilon)
             let is_duplicate = unique_positions.iter().any(|existing: &Vec3| {
                 (existing.x - pos.x).abs() < EPSILON

--- a/crates/bevy_granite_gizmos/src/gizmos/vertex/spawn.rs
+++ b/crates/bevy_granite_gizmos/src/gizmos/vertex/spawn.rs
@@ -1,0 +1,227 @@
+use super::{
+    components::{HasVertexVisualizations, VertexMarker, VertexVisualizationParent},
+    config::VertexVisualizationConfig,
+};
+use crate::{
+    gizmos::{GizmoType, NewGizmoType},
+    selection::Selected,
+};
+use bevy::{
+    ecs::hierarchy::ChildOf,
+    light::{NotShadowCaster, NotShadowReceiver},
+    mesh::{Mesh3d, VertexAttributeValues},
+    pbr::MeshMaterial3d,
+    picking::Pickable,
+    prelude::{
+        Assets, Children, Commands, Cuboid, Entity, Mesh, Meshable, Name, Query, Res, ResMut,
+        StandardMaterial, Transform, Vec3, Visibility, With, Without,
+    },
+};
+use bevy_granite_core::{EditorIgnore, TreeHiddenEntity};
+use bevy_granite_logging::{
+    config::{LogCategory, LogLevel, LogType},
+    log,
+};
+
+/// System that spawns vertex visualizations for all selected entities
+pub fn spawn_vertex_visualizations(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+    config: Res<VertexVisualizationConfig>,
+    gizmo_type: Res<NewGizmoType>,
+    selected_entities: Query<
+        (Entity, &Mesh3d),
+        (With<Selected>, Without<HasVertexVisualizations>),
+    >,
+) {
+    // Only spawn if in Pointer mode and enabled
+    if !matches!(**gizmo_type, GizmoType::Pointer) || !config.enabled {
+        return;
+    }
+
+    for (entity, mesh3d) in selected_entities.iter() {
+        // Get the mesh asset
+        let Some(mesh) = meshes.get(&mesh3d.0) else {
+            continue;
+        };
+
+        // Extract vertex positions
+        let Some(vertex_positions) = extract_vertex_positions(mesh) else {
+            log!(
+                LogType::Editor,
+                LogLevel::Warning,
+                LogCategory::Entity,
+                "Failed to extract vertex positions from mesh on entity {:?}",
+                entity
+            );
+            continue;
+        };
+
+        log!(
+            LogType::Editor,
+            LogLevel::Info,
+            LogCategory::Entity,
+            "Spawning {} vertex markers for entity {:?}",
+            vertex_positions.len(),
+            entity
+        );
+
+        // Create parent entity to hold all vertex markers
+        let parent = commands
+            .spawn((
+                Transform::default(),
+                Visibility::default(),
+                VertexVisualizationParent {
+                    source_entity: entity,
+                },
+                ChildOf(entity),
+                TreeHiddenEntity,
+                Name::new("VertexVisualizationParent"),
+            ))
+            .id();
+
+        // Spawn a cube for each vertex
+        for (index, position) in vertex_positions.iter().enumerate() {
+            let mesh_handle = meshes.add(Cuboid::new(config.vertex_size, config.vertex_size, config.vertex_size).mesh());
+
+            // Create a unique material for each vertex so they can be colored independently
+            // Disable depth write to make vertices visible through the mesh
+            let material = materials.add(StandardMaterial {
+                base_color: config.unselected_color,
+                unlit: true,
+                alpha_mode: bevy::prelude::AlphaMode::Blend,
+                depth_bias: -0.1, // Negative bias helps with z-fighting
+                ..Default::default()
+            });
+
+            commands.spawn((
+                Mesh3d(mesh_handle),
+                MeshMaterial3d(material),
+                Transform::from_translation(*position),
+                Visibility::default(),
+                VertexMarker {
+                    parent_entity: entity,
+                    vertex_index: index,
+                    local_position: *position,
+                },
+                Pickable {
+                    is_hoverable: true,
+                    should_block_lower: true,
+                },
+                EditorIgnore::PICKING,
+                NotShadowCaster,
+                NotShadowReceiver,
+                ChildOf(parent),
+                TreeHiddenEntity,
+                Name::new(format!("Vertex_{}", index)),
+            ));
+        }
+
+        // Mark the entity as having vertex visualizations
+        // Use queue to defer the command and silently fail if entity doesn't exist
+        commands
+            .entity(entity)
+            .queue_silenced(|mut entity: bevy::ecs::world::EntityWorldMut| {
+                entity.insert(HasVertexVisualizations);
+            });
+    }
+}
+
+/// System that despawns vertex visualizations when conditions aren't met
+pub fn despawn_vertex_visualizations(
+    mut commands: Commands,
+    config: Res<VertexVisualizationConfig>,
+    gizmo_type: Res<NewGizmoType>,
+    vertex_parents: Query<(Entity, &VertexVisualizationParent, &Children)>,
+    selected_entities: Query<(), With<Selected>>,
+) {
+    let should_despawn = !matches!(**gizmo_type, GizmoType::Pointer)
+        || !config.enabled
+        || selected_entities.is_empty();
+
+    if should_despawn {
+        for (parent_entity, viz_parent, children) in vertex_parents.iter() {
+            // Despawn all vertex marker children
+            for child in children.iter() {
+                if let Ok(mut entity_commands) = commands.get_entity(*child) {
+                    entity_commands.despawn();
+                }
+            }
+            // Despawn the parent
+            if let Ok(mut entity_commands) = commands.get_entity(parent_entity) {
+                entity_commands.despawn();
+            }
+            // Remove the marker from the source entity
+            commands
+                .entity(viz_parent.source_entity)
+                .remove::<HasVertexVisualizations>();
+        }
+
+        if !vertex_parents.is_empty() {
+            log!(
+                LogType::Editor,
+                LogLevel::Info,
+                LogCategory::Entity,
+                "Despawned vertex visualizations"
+            );
+        }
+    }
+}
+
+/// System that despawns vertex visualizations when an entity is deselected
+pub fn cleanup_deselected_entity_vertices(
+    mut commands: Commands,
+    vertex_parents: Query<(Entity, &VertexVisualizationParent, &Children)>,
+    selected_entities: Query<Entity, With<Selected>>,
+) {
+    for (parent_entity, viz_parent, children) in vertex_parents.iter() {
+        // Check if the source entity is still selected
+        if selected_entities.get(viz_parent.source_entity).is_err() {
+            // Entity is no longer selected, despawn its vertices
+            for child in children.iter() {
+                if let Ok(mut entity_commands) = commands.get_entity(*child) {
+                    entity_commands.despawn();
+                }
+            }
+            if let Ok(mut entity_commands) = commands.get_entity(parent_entity) {
+                entity_commands.despawn();
+            }
+            // Remove the marker from the source entity
+            commands
+                .entity(viz_parent.source_entity)
+                .remove::<HasVertexVisualizations>();
+        }
+    }
+}
+
+/// Extract unique vertex positions from a mesh
+/// Deduplicates vertices that share the same position
+fn extract_vertex_positions(mesh: &Mesh) -> Option<Vec<Vec3>> {
+    let positions = mesh.attribute(Mesh::ATTRIBUTE_POSITION)?;
+
+    if let VertexAttributeValues::Float32x3(positions) = positions {
+        // Use a simple deduplication by converting to a set-like structure
+        let mut unique_positions = Vec::new();
+        const EPSILON: f32 = 0.0001; // Small tolerance for floating point comparison
+
+        for [x, y, z] in positions {
+            let pos = Vec3::new(*x, *y, *z);
+            
+            // Check if this position already exists (within epsilon)
+            let is_duplicate = unique_positions.iter().any(|existing: &Vec3| {
+                (existing.x - pos.x).abs() < EPSILON
+                    && (existing.y - pos.y).abs() < EPSILON
+                    && (existing.z - pos.z).abs() < EPSILON
+            });
+
+            if !is_duplicate {
+                unique_positions.push(pos);
+            }
+        }
+
+        Some(unique_positions)
+    } else {
+        None
+    }
+}

--- a/crates/bevy_granite_gizmos/src/lib.rs
+++ b/crates/bevy_granite_gizmos/src/lib.rs
@@ -24,6 +24,7 @@ pub use selection::{
 };
 
 // Internal plugins
+use gizmos::vertex::VertexVisualizationPlugin;
 use gizmos::GizmoPlugin;
 use input::InputPlugin;
 use selection::SelectionPlugin;
@@ -55,6 +56,7 @@ impl Plugin for BevyGraniteGizmos {
             //
             // internal
             .add_plugins(GizmoPlugin)
+            .add_plugins(VertexVisualizationPlugin) // Vertex picking must be BEFORE SelectionPlugin for priority
             .add_plugins(SelectionPlugin)
             .add_plugins(UIPlugin)
             .add_plugins(InputPlugin) // Optional

--- a/crates/bevy_granite_gizmos/src/selection/ray.rs
+++ b/crates/bevy_granite_gizmos/src/selection/ray.rs
@@ -24,6 +24,7 @@ pub enum HitType {
     Gizmo,
     Icon,
     Mesh,
+    Vertex,
     Void,
     None,
 }

--- a/crates/bevy_granite_gizmos/src/ui/panel.rs
+++ b/crates/bevy_granite_gizmos/src/ui/panel.rs
@@ -1,12 +1,15 @@
 use bevy::{
     ecs::{query::With, system::Query},
-    prelude::ResMut,
+    prelude::{Res, ResMut},
 };
 use bevy_egui::{egui, EguiContexts};
 use bevy_granite_logging::{log, LogCategory, LogLevel, LogType};
 
 use crate::{
-    gizmos::{GizmoConfig, GizmoMode, GizmoSnap, GizmoType, Gizmos, NewGizmoConfig, NewGizmoType},
+    gizmos::{
+        vertex::{SelectedVertex, VertexMarker, VertexSelectionState, VertexVisualizationConfig},
+        GizmoConfig, GizmoMode, GizmoSnap, GizmoType, Gizmos, NewGizmoConfig, NewGizmoType,
+    },
     ActiveSelection,
 };
 
@@ -15,11 +18,18 @@ pub fn editor_gizmos_ui(
     mut selected_option: ResMut<NewGizmoType>,
     mut gizmo_snap: ResMut<GizmoSnap>,
     mut config: ResMut<NewGizmoConfig>,
+    mut vertex_config: ResMut<VertexVisualizationConfig>,
+    vertex_state: Res<VertexSelectionState>,
     selected_entity: Query<&Gizmos, With<ActiveSelection>>,
     mut gizmos: Query<&mut GizmoConfig>,
+    selected_vertices: Query<
+        (&VertexMarker, &bevy::prelude::GlobalTransform),
+        With<SelectedVertex>,
+    >,
 ) {
     let small_spacing = 1.;
     let spacing = 4.;
+    let large_spacing = 6.;
     egui::Window::new("Gizmos")
         .resizable(false)
         .title_bar(false)
@@ -41,10 +51,191 @@ pub fn editor_gizmos_ui(
                             }
                         }
                     }
-                    ui.set_max_width(100.);
+                    ui.set_max_width(200.);
                     changed |= ui
                         .radio_value(&mut active, GizmoType::Pointer, "Pointer")
                         .changed();
+
+                    // Vertex visualization options for Pointer mode
+                    if matches!(active, GizmoType::Pointer) {
+                        ui.add_space(spacing);
+                        if ui
+                            .checkbox(&mut vertex_config.enabled, "Show Vertices")
+                            .changed()
+                        {
+                            log!(
+                                LogType::Editor,
+                                LogLevel::Info,
+                                LogCategory::Entity,
+                                "Vertex visualization {}",
+                                if vertex_config.enabled {
+                                    "enabled"
+                                } else {
+                                    "disabled"
+                                }
+                            );
+                        }
+
+                        // Show info about selected vertices
+                        if !selected_vertices.is_empty() {
+                            ui.add_space(large_spacing);
+                            ui.group(|ui| {
+                            ui.add_space(small_spacing);
+
+                            // Show world position, rotation, and scale for single vertex
+                            if selected_vertices.iter().count() == 1 {
+                                if let Some((_vertex_marker, global_transform)) =
+                                    selected_vertices.iter().next()
+                                {
+                                    let (scale, rot_quat, pos) = global_transform
+                                        .to_scale_rotation_translation();
+                                    let rot = rot_quat
+                                        .to_euler(bevy::prelude::EulerRot::YXZ);
+
+                                ui.add_space(spacing);
+                                ui.label("Vertex");
+                                ui.add_space(spacing);
+                                    
+                                    // Display transform as a clean grid
+                                    egui::Grid::new("vertex_transform_grid")
+                                        .num_columns(4)
+                                        .spacing([2.0, 2.0])
+                                        .striped(false)
+                                        .show(ui, |ui| {
+                                            let drag_width = 60.0;
+                                            
+                                            // Position row
+                                            ui.label("Position: ");
+                                            ui.add_sized([drag_width, 20.0], egui::DragValue::new(&mut pos.x.clone()).speed(0.1).max_decimals(2).min_decimals(2).fixed_decimals(2));
+                                            ui.add_sized([drag_width, 20.0], egui::DragValue::new(&mut pos.y.clone()).speed(0.1).max_decimals(2).min_decimals(2).fixed_decimals(2));
+                                            ui.add_sized([drag_width, 20.0], egui::DragValue::new(&mut pos.z.clone()).speed(0.1).max_decimals(2).min_decimals(2).fixed_decimals(2));
+                                            ui.end_row();
+                                            
+                                            // Rotation row (convert from YXZ back to XYZ for display)
+                                            let rot_degrees = (
+                                                rot.1.to_degrees(), // X
+                                                rot.0.to_degrees(), // Y
+                                                rot.2.to_degrees(), // Z
+                                            );
+                                            ui.label("Rotation: ");
+                                            ui.add_sized([drag_width, 20.0], egui::DragValue::new(&mut rot_degrees.0.clone()).speed(1.0).max_decimals(2).min_decimals(2).fixed_decimals(2));
+                                            ui.add_sized([drag_width, 20.0], egui::DragValue::new(&mut rot_degrees.1.clone()).speed(1.0).max_decimals(2).min_decimals(2).fixed_decimals(2));
+                                            ui.add_sized([drag_width, 20.0], egui::DragValue::new(&mut rot_degrees.2.clone()).speed(1.0).max_decimals(2).min_decimals(2).fixed_decimals(2));
+                                            ui.end_row();
+                                            
+                                            // Scale row
+                                            ui.label("Scale: ");
+                                            ui.add_sized([drag_width, 20.0], egui::DragValue::new(&mut scale.x.clone()).speed(0.01).max_decimals(2).min_decimals(2).fixed_decimals(2));
+                                            ui.add_sized([drag_width, 20.0], egui::DragValue::new(&mut scale.y.clone()).speed(0.01).max_decimals(2).min_decimals(2).fixed_decimals(2));
+                                            ui.add_sized([drag_width, 20.0], egui::DragValue::new(&mut scale.z.clone()).speed(0.01).max_decimals(2).min_decimals(2).fixed_decimals(2));
+                                            ui.end_row();
+                                        });
+
+                                    ui.add_space(spacing);
+                                    
+                                    // Copy full transform matrix button
+                                    if ui.button("Copy Matrix").clicked() {
+                                        let affine = global_transform.affine();
+                                        let matrix = affine.matrix3;
+                                        let translation = affine.translation;
+                                        ui.ctx().copy_text(format!(
+                                            "[{}, {}, {}, 0.0]\n[{}, {}, {}, 0.0]\n[{}, {}, {}, 0.0]\n[{}, {}, {}, 1.0]",
+                                            matrix.x_axis.x, matrix.x_axis.y, matrix.x_axis.z,
+                                            matrix.y_axis.x, matrix.y_axis.y, matrix.y_axis.z,
+                                            matrix.z_axis.x, matrix.z_axis.y, matrix.z_axis.z,
+                                            translation.x, translation.y, translation.z,
+                                        ));
+                                    }
+                                }
+                            }
+
+                            // Show midpoint for multiple vertices
+                            if let Some(midpoint) = vertex_state.midpoint_world {
+                                // Calculate average rotation and scale from all selected vertices
+                                let mut avg_rotation = bevy::prelude::Quat::IDENTITY;
+                                let mut avg_scale = bevy::prelude::Vec3::ZERO;
+                                let count = selected_vertices.iter().count() as f32;
+                                
+                                if count > 0.0 {
+                                    for (_marker, transform) in selected_vertices.iter() {
+                                        let (scale, rotation, _pos) = transform.to_scale_rotation_translation();
+                                        avg_scale += scale;
+                                        // For quaternions, we use SLERP-style averaging
+                                        avg_rotation = if avg_rotation == bevy::prelude::Quat::IDENTITY {
+                                            rotation
+                                        } else {
+                                            avg_rotation.slerp(rotation, 1.0 / count)
+                                        };
+                                    }
+                                    avg_scale /= count;
+                                }
+                                
+                                let rot = avg_rotation.to_euler(bevy::prelude::EulerRot::YXZ);
+                                let rot_degrees = (
+                                    rot.1.to_degrees(), // X
+                                    rot.0.to_degrees(), // Y
+                                    rot.2.to_degrees(), // Z
+                                );
+
+                                ui.add_space(spacing);
+                                ui.label("Midpoint");
+                                ui.add_space(spacing);
+                                
+                                // Display midpoint transform as a clean grid
+                                egui::Grid::new("midpoint_transform_grid")
+                                    .num_columns(4)
+                                    .spacing([2.0, 2.0])
+                                    .striped(false)
+                                    .show(ui, |ui| {
+                                        let drag_width = 60.0;
+                                        
+                                        // Position row
+                                        ui.label("Position: ");
+                                        ui.add_sized([drag_width, 20.0], egui::DragValue::new(&mut midpoint.x.clone()).speed(0.1).max_decimals(2).min_decimals(2).fixed_decimals(2));
+                                        ui.add_sized([drag_width, 20.0], egui::DragValue::new(&mut midpoint.y.clone()).speed(0.1).max_decimals(2).min_decimals(2).fixed_decimals(2));
+                                        ui.add_sized([drag_width, 20.0], egui::DragValue::new(&mut midpoint.z.clone()).speed(0.1).max_decimals(2).min_decimals(2).fixed_decimals(2));
+                                        ui.end_row();
+                                        
+                                        // Rotation row (averaged from selected vertices)
+                                        ui.label("Rotation: ");
+                                        ui.add_sized([drag_width, 20.0], egui::DragValue::new(&mut rot_degrees.0.clone()).speed(1.0).max_decimals(2).min_decimals(2).fixed_decimals(2));
+                                        ui.add_sized([drag_width, 20.0], egui::DragValue::new(&mut rot_degrees.1.clone()).speed(1.0).max_decimals(2).min_decimals(2).fixed_decimals(2));
+                                        ui.add_sized([drag_width, 20.0], egui::DragValue::new(&mut rot_degrees.2.clone()).speed(1.0).max_decimals(2).min_decimals(2).fixed_decimals(2));
+                                        ui.end_row();
+                                        
+                                        // Scale row (averaged from selected vertices)
+                                        ui.label("Scale: ");
+                                        ui.add_sized([drag_width, 20.0], egui::DragValue::new(&mut avg_scale.x.clone()).speed(0.01).max_decimals(2).min_decimals(2).fixed_decimals(2));
+                                        ui.add_sized([drag_width, 20.0], egui::DragValue::new(&mut avg_scale.y.clone()).speed(0.01).max_decimals(2).min_decimals(2).fixed_decimals(2));
+                                        ui.add_sized([drag_width, 20.0], egui::DragValue::new(&mut avg_scale.z.clone()).speed(0.01).max_decimals(2).min_decimals(2).fixed_decimals(2));
+                                        ui.end_row();
+                                    });
+
+                                ui.add_space(spacing);
+                                
+                                // Copy midpoint matrix button
+                                if ui.button("Copy Matrix").clicked() {
+                                    // Create a full transform matrix with averaged rotation and scale
+                                    let affine = bevy::math::Affine3A::from_scale_rotation_translation(
+                                        avg_scale,
+                                        avg_rotation,
+                                        midpoint,
+                                    );
+                                    let matrix = affine.matrix3;
+                                    let translation = affine.translation;
+                                    ui.ctx().copy_text(format!(
+                                        "[{}, {}, {}, 0.0]\n[{}, {}, {}, 0.0]\n[{}, {}, {}, 0.0]\n[{}, {}, {}, 1.0]",
+                                        matrix.x_axis.x, matrix.x_axis.y, matrix.x_axis.z,
+                                        matrix.y_axis.x, matrix.y_axis.y, matrix.y_axis.z,
+                                        matrix.z_axis.x, matrix.z_axis.y, matrix.z_axis.z,
+                                        translation.x, translation.y, translation.z,
+                                    ));
+                                }
+                            }
+                            });
+                        }
+                    }
+
                     ui.separator();
                     changed |= ui
                         .radio_value(&mut active, GizmoType::Transform, "Move")
@@ -121,7 +312,7 @@ pub fn editor_gizmos_ui(
                         };
                         gizmo.set_type(active, &config);
                         gizmo.set_mode(mode);
-                        config.mode = mode; 
+                        config.mode = mode;
                         **selected_option = active;
                     } else {
                         config.mode = mode;

--- a/crates/bevy_granite_gizmos/src/ui/panel.rs
+++ b/crates/bevy_granite_gizmos/src/ui/panel.rs
@@ -51,7 +51,7 @@ pub fn editor_gizmos_ui(
                             }
                         }
                     }
-                    ui.set_max_width(200.);
+                    ui.set_max_width(150.);
                     changed |= ui
                         .radio_value(&mut active, GizmoType::Pointer, "Pointer")
                         .changed();
@@ -60,7 +60,7 @@ pub fn editor_gizmos_ui(
                     if matches!(active, GizmoType::Pointer) {
                         ui.add_space(spacing);
                         if ui
-                            .checkbox(&mut vertex_config.enabled, "Show Vertices")
+                            .checkbox(&mut vertex_config.enabled, "Show Verts")
                             .changed()
                         {
                             log!(
@@ -82,7 +82,6 @@ pub fn editor_gizmos_ui(
                             ui.group(|ui| {
                             ui.add_space(small_spacing);
 
-                            // Show world position, rotation, and scale for single vertex
                             if selected_vertices.iter().count() == 1 {
                                 if let Some((_vertex_marker, global_transform)) =
                                     selected_vertices.iter().next()
@@ -96,7 +95,6 @@ pub fn editor_gizmos_ui(
                                 ui.label("Vertex");
                                 ui.add_space(spacing);
                                     
-                                    // Display transform as a clean grid
                                     egui::Grid::new("vertex_transform_grid")
                                         .num_columns(4)
                                         .spacing([2.0, 2.0])
@@ -104,18 +102,16 @@ pub fn editor_gizmos_ui(
                                         .show(ui, |ui| {
                                             let drag_width = 60.0;
                                             
-                                            // Position row
                                             ui.label("Position: ");
                                             ui.add_sized([drag_width, 20.0], egui::DragValue::new(&mut pos.x.clone()).speed(0.1).max_decimals(2).min_decimals(2).fixed_decimals(2));
                                             ui.add_sized([drag_width, 20.0], egui::DragValue::new(&mut pos.y.clone()).speed(0.1).max_decimals(2).min_decimals(2).fixed_decimals(2));
                                             ui.add_sized([drag_width, 20.0], egui::DragValue::new(&mut pos.z.clone()).speed(0.1).max_decimals(2).min_decimals(2).fixed_decimals(2));
                                             ui.end_row();
                                             
-                                            // Rotation row (convert from YXZ back to XYZ for display)
                                             let rot_degrees = (
-                                                rot.1.to_degrees(), // X
-                                                rot.0.to_degrees(), // Y
-                                                rot.2.to_degrees(), // Z
+                                                rot.1.to_degrees(), 
+                                                rot.0.to_degrees(), 
+                                                rot.2.to_degrees(), 
                                             );
                                             ui.label("Rotation: ");
                                             ui.add_sized([drag_width, 20.0], egui::DragValue::new(&mut rot_degrees.0.clone()).speed(1.0).max_decimals(2).min_decimals(2).fixed_decimals(2));
@@ -123,7 +119,6 @@ pub fn editor_gizmos_ui(
                                             ui.add_sized([drag_width, 20.0], egui::DragValue::new(&mut rot_degrees.2.clone()).speed(1.0).max_decimals(2).min_decimals(2).fixed_decimals(2));
                                             ui.end_row();
                                             
-                                            // Scale row
                                             ui.label("Scale: ");
                                             ui.add_sized([drag_width, 20.0], egui::DragValue::new(&mut scale.x.clone()).speed(0.01).max_decimals(2).min_decimals(2).fixed_decimals(2));
                                             ui.add_sized([drag_width, 20.0], egui::DragValue::new(&mut scale.y.clone()).speed(0.01).max_decimals(2).min_decimals(2).fixed_decimals(2));
@@ -133,8 +128,7 @@ pub fn editor_gizmos_ui(
 
                                     ui.add_space(spacing);
                                     
-                                    // Copy full transform matrix button
-                                    if ui.button("Copy Matrix").clicked() {
+                                    if ui.button("Copy").clicked() {
                                         let affine = global_transform.affine();
                                         let matrix = affine.matrix3;
                                         let translation = affine.translation;
@@ -151,7 +145,6 @@ pub fn editor_gizmos_ui(
 
                             // Show midpoint for multiple vertices
                             if let Some(midpoint) = vertex_state.midpoint_world {
-                                // Calculate average rotation and scale from all selected vertices
                                 let mut avg_rotation = bevy::prelude::Quat::IDENTITY;
                                 let mut avg_scale = bevy::prelude::Vec3::ZERO;
                                 let count = selected_vertices.iter().count() as f32;
@@ -160,7 +153,6 @@ pub fn editor_gizmos_ui(
                                     for (_marker, transform) in selected_vertices.iter() {
                                         let (scale, rotation, _pos) = transform.to_scale_rotation_translation();
                                         avg_scale += scale;
-                                        // For quaternions, we use SLERP-style averaging
                                         avg_rotation = if avg_rotation == bevy::prelude::Quat::IDENTITY {
                                             rotation
                                         } else {
@@ -172,16 +164,15 @@ pub fn editor_gizmos_ui(
                                 
                                 let rot = avg_rotation.to_euler(bevy::prelude::EulerRot::YXZ);
                                 let rot_degrees = (
-                                    rot.1.to_degrees(), // X
-                                    rot.0.to_degrees(), // Y
-                                    rot.2.to_degrees(), // Z
+                                    rot.1.to_degrees(), 
+                                    rot.0.to_degrees(), 
+                                    rot.2.to_degrees(), 
                                 );
 
                                 ui.add_space(spacing);
                                 ui.label("Midpoint");
                                 ui.add_space(spacing);
                                 
-                                // Display midpoint transform as a clean grid
                                 egui::Grid::new("midpoint_transform_grid")
                                     .num_columns(4)
                                     .spacing([2.0, 2.0])
@@ -189,21 +180,18 @@ pub fn editor_gizmos_ui(
                                     .show(ui, |ui| {
                                         let drag_width = 60.0;
                                         
-                                        // Position row
                                         ui.label("Position: ");
                                         ui.add_sized([drag_width, 20.0], egui::DragValue::new(&mut midpoint.x.clone()).speed(0.1).max_decimals(2).min_decimals(2).fixed_decimals(2));
                                         ui.add_sized([drag_width, 20.0], egui::DragValue::new(&mut midpoint.y.clone()).speed(0.1).max_decimals(2).min_decimals(2).fixed_decimals(2));
                                         ui.add_sized([drag_width, 20.0], egui::DragValue::new(&mut midpoint.z.clone()).speed(0.1).max_decimals(2).min_decimals(2).fixed_decimals(2));
                                         ui.end_row();
                                         
-                                        // Rotation row (averaged from selected vertices)
                                         ui.label("Rotation: ");
                                         ui.add_sized([drag_width, 20.0], egui::DragValue::new(&mut rot_degrees.0.clone()).speed(1.0).max_decimals(2).min_decimals(2).fixed_decimals(2));
                                         ui.add_sized([drag_width, 20.0], egui::DragValue::new(&mut rot_degrees.1.clone()).speed(1.0).max_decimals(2).min_decimals(2).fixed_decimals(2));
                                         ui.add_sized([drag_width, 20.0], egui::DragValue::new(&mut rot_degrees.2.clone()).speed(1.0).max_decimals(2).min_decimals(2).fixed_decimals(2));
                                         ui.end_row();
                                         
-                                        // Scale row (averaged from selected vertices)
                                         ui.label("Scale: ");
                                         ui.add_sized([drag_width, 20.0], egui::DragValue::new(&mut avg_scale.x.clone()).speed(0.01).max_decimals(2).min_decimals(2).fixed_decimals(2));
                                         ui.add_sized([drag_width, 20.0], egui::DragValue::new(&mut avg_scale.y.clone()).speed(0.01).max_decimals(2).min_decimals(2).fixed_decimals(2));
@@ -214,8 +202,7 @@ pub fn editor_gizmos_ui(
                                 ui.add_space(spacing);
                                 
                                 // Copy midpoint matrix button
-                                if ui.button("Copy Matrix").clicked() {
-                                    // Create a full transform matrix with averaged rotation and scale
+                                if ui.button("Copy").clicked() {
                                     let affine = bevy::math::Affine3A::from_scale_rotation_translation(
                                         avg_scale,
                                         avg_rotation,


### PR DESCRIPTION
- Added a new mode on the Pointer gizmo to enable viewing of vertex positions
- When vertex visualizer is enabled, you can view a single vertex position, or multiple verts midpoint
- Add new buttons to copy/paste transforms 


This allows you to get precise vertex positional data (**_no_** vertex rotation) and copy that data optionally to other entities without having to go back and forth between DCCs.

<img width="2808" height="1476" alt="image" src="https://github.com/user-attachments/assets/37c22d1b-51d0-4bf6-a4eb-ffa05003fee7" />

