### PR TITLE
Add camera atmosphere settings

### DIFF
--- a/crates/bevy_granite_core/src/entities/editable/types/camera_3d/creation.rs
+++ b/crates/bevy_granite_core/src/entities/editable/types/camera_3d/creation.rs
@@ -4,10 +4,7 @@ use crate::{
     HasRuntimeData, IdentityData,
 };
 use bevy::{
-    camera::{Camera, Camera3d},
-    ecs::{bundle::Bundle, entity::Entity, system::Commands},
-    prelude::Name,
-    transform::components::Transform,
+    camera::{Camera, Camera3d}, ecs::{bundle::Bundle, entity::Entity, system::Commands}, prelude::Name, render::view::Hdr, transform::components::Transform
 };
 use uuid::Uuid;
 
@@ -78,6 +75,41 @@ impl Camera3D {
             //I don't know if the fog volume should be attached to the camera or its own entity
             entity.insert((fog, fog_volume));
         }
+
+        // Handle atmosphere settings
+        if self.has_atmosphere {
+            if let Some(atmos_settings) = &self.atmosphere_settings {
+                // Add Atmosphere component (using EARTH preset if enabled, otherwise use custom values)
+                let atmosphere = if atmos_settings.use_earth_preset {
+                    bevy::pbr::Atmosphere::EARTH
+                } else {
+                    bevy::pbr::Atmosphere {
+                        bottom_radius: atmos_settings.bottom_radius,
+                        top_radius: atmos_settings.top_radius,
+                        ground_albedo: atmos_settings.ground_albedo.into(),
+                        rayleigh_density_exp_scale: atmos_settings.rayleigh_density_exp_scale,
+                        rayleigh_scattering: atmos_settings.rayleigh_scattering.into(),
+                        mie_density_exp_scale: atmos_settings.mie_density_exp_scale,
+                        mie_scattering: atmos_settings.mie_scattering,
+                        mie_absorption: atmos_settings.mie_absorption,
+                        mie_asymmetry: atmos_settings.mie_asymmetry,
+                        ozone_layer_altitude: atmos_settings.ozone_layer_altitude,
+                        ozone_layer_width: atmos_settings.ozone_layer_width,
+                        ozone_absorption: atmos_settings.ozone_absorption.into(),
+                    }
+                };
+                entity.insert(Hdr);
+                entity.insert(atmosphere);
+
+                // Add AtmosphereSettings component
+                entity.insert(bevy::pbr::AtmosphereSettings {
+                    aerial_view_lut_max_distance: atmos_settings.aerial_view_lut_max_distance,
+                    scene_units_to_m: atmos_settings.scene_units_to_m,
+                    ..Default::default()
+                });
+            }
+        }
+
         entity.id()
     }
 
@@ -91,6 +123,7 @@ impl Camera3D {
             Camera3d::default(),
             Camera {
                 is_active: camera_3d.is_active,
+                order: camera_3d.order,
                 ..Default::default()
             },
             transform,

--- a/crates/bevy_granite_core/src/entities/editable/types/camera_3d/creation.rs
+++ b/crates/bevy_granite_core/src/entities/editable/types/camera_3d/creation.rs
@@ -79,32 +79,55 @@ impl Camera3D {
         // Handle atmosphere settings
         if self.has_atmosphere {
             if let Some(atmos_settings) = &self.atmosphere_settings {
-                // Add Atmosphere component (using EARTH preset if enabled, otherwise use custom values)
-                let atmosphere = if atmos_settings.use_earth_preset {
-                    bevy::pbr::Atmosphere::EARTH
-                } else {
-                    bevy::pbr::Atmosphere {
-                        bottom_radius: atmos_settings.bottom_radius,
-                        top_radius: atmos_settings.top_radius,
-                        ground_albedo: atmos_settings.ground_albedo.into(),
-                        rayleigh_density_exp_scale: atmos_settings.rayleigh_density_exp_scale,
-                        rayleigh_scattering: atmos_settings.rayleigh_scattering.into(),
-                        mie_density_exp_scale: atmos_settings.mie_density_exp_scale,
-                        mie_scattering: atmos_settings.mie_scattering,
-                        mie_absorption: atmos_settings.mie_absorption,
-                        mie_asymmetry: atmos_settings.mie_asymmetry,
-                        ozone_layer_altitude: atmos_settings.ozone_layer_altitude,
-                        ozone_layer_width: atmos_settings.ozone_layer_width,
-                        ozone_absorption: atmos_settings.ozone_absorption.into(),
-                    }
+                // Always use custom values from the settings
+                let atmosphere = bevy::pbr::Atmosphere {
+                    bottom_radius: atmos_settings.bottom_radius,
+                    top_radius: atmos_settings.top_radius,
+                    ground_albedo: atmos_settings.ground_albedo.into(),
+                    rayleigh_density_exp_scale: atmos_settings.rayleigh_density_exp_scale,
+                    rayleigh_scattering: atmos_settings.rayleigh_scattering.into(),
+                    mie_density_exp_scale: atmos_settings.mie_density_exp_scale,
+                    mie_scattering: atmos_settings.mie_scattering,
+                    mie_absorption: atmos_settings.mie_absorption,
+                    mie_asymmetry: atmos_settings.mie_asymmetry,
+                    ozone_layer_altitude: atmos_settings.ozone_layer_altitude,
+                    ozone_layer_width: atmos_settings.ozone_layer_width,
+                    ozone_absorption: atmos_settings.ozone_absorption.into(),
                 };
                 entity.insert(Hdr);
                 entity.insert(atmosphere);
 
-                // Add AtmosphereSettings component
+                // Add AtmosphereSettings component with all LUT settings
                 entity.insert(bevy::pbr::AtmosphereSettings {
+                    transmittance_lut_size: bevy::math::UVec2::new(
+                        atmos_settings.transmittance_lut_size.0,
+                        atmos_settings.transmittance_lut_size.1,
+                    ),
+                    multiscattering_lut_size: bevy::math::UVec2::new(
+                        atmos_settings.multiscattering_lut_size.0,
+                        atmos_settings.multiscattering_lut_size.1,
+                    ),
+                    sky_view_lut_size: bevy::math::UVec2::new(
+                        atmos_settings.sky_view_lut_size.0,
+                        atmos_settings.sky_view_lut_size.1,
+                    ),
+                    aerial_view_lut_size: bevy::math::UVec3::new(
+                        atmos_settings.aerial_view_lut_size.0,
+                        atmos_settings.aerial_view_lut_size.1,
+                        atmos_settings.aerial_view_lut_size.2,
+                    ),
+                    transmittance_lut_samples: atmos_settings.transmittance_lut_samples,
+                    multiscattering_lut_dirs: atmos_settings.multiscattering_lut_dirs,
+                    multiscattering_lut_samples: atmos_settings.multiscattering_lut_samples,
+                    sky_view_lut_samples: atmos_settings.sky_view_lut_samples,
+                    aerial_view_lut_samples: atmos_settings.aerial_view_lut_samples,
                     aerial_view_lut_max_distance: atmos_settings.aerial_view_lut_max_distance,
                     scene_units_to_m: atmos_settings.scene_units_to_m,
+                    sky_max_samples: atmos_settings.sky_max_samples,
+                    rendering_method: match atmos_settings.rendering_method {
+                        super::AtmosphereRenderingMethod::LookupTexture => bevy::pbr::AtmosphereMode::LookupTexture,
+                        super::AtmosphereRenderingMethod::Raymarched => bevy::pbr::AtmosphereMode::Raymarched,
+                    },
                     ..Default::default()
                 });
             }

--- a/crates/bevy_granite_core/src/entities/editable/types/camera_3d/mod.rs
+++ b/crates/bevy_granite_core/src/entities/editable/types/camera_3d/mod.rs
@@ -10,8 +10,7 @@ use bevy::{
     },
     mesh::Mesh,
     pbr::StandardMaterial,
-    prelude::{Reflect, ReflectDefault},
-    reflect::FromReflect,
+    prelude::Reflect,
     transform::components::Transform,
 };
 use bevy_egui::egui;
@@ -98,13 +97,33 @@ impl Default for VolumetricFog {
     }
 }
 
+/// Serializable version of Bevy's AtmosphereMode enum
+#[derive(Serialize, Deserialize, Reflect, Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AtmosphereRenderingMethod {
+    #[default]
+    LookupTexture,
+    Raymarched,
+}
+
 /// Wrapper for bevy atmosphere settings that's serializable and optional
 /// Will need to keep in parity if Bevy changes how it stores these settings
 #[derive(Serialize, Deserialize, Reflect, Debug, Clone, PartialEq)]
 pub struct AtmosphereSettings {
+    // LUT (Look-Up Table) Settings
+    pub transmittance_lut_size: (u32, u32),     // UVec2 as tuple
+    pub multiscattering_lut_size: (u32, u32),   // UVec2 as tuple
+    pub sky_view_lut_size: (u32, u32),          // UVec2 as tuple
+    pub aerial_view_lut_size: (u32, u32, u32),  // UVec3 as tuple
+    pub transmittance_lut_samples: u32,
+    pub multiscattering_lut_dirs: u32,
+    pub multiscattering_lut_samples: u32,
+    pub sky_view_lut_samples: u32,
+    pub aerial_view_lut_samples: u32,
     pub aerial_view_lut_max_distance: f32,
     pub scene_units_to_m: f32,
-    pub use_earth_preset: bool, // If true, uses Atmosphere::EARTH preset
+    pub sky_max_samples: u32,
+    pub rendering_method: AtmosphereRenderingMethod,
+    
     // Atmosphere component fields
     pub bottom_radius: f32,
     pub top_radius: f32,
@@ -121,13 +140,26 @@ pub struct AtmosphereSettings {
 }
 impl Default for AtmosphereSettings {
     fn default() -> Self {
-        // Scaled for small scenes (100m x 100m)
+        // Default values based on Bevy's AtmosphereSettings::default()
         Self {
-            aerial_view_lut_max_distance:  3.2e5,
-            scene_units_to_m: 1.0,                // 1 scene unit = 1 meter
-            use_earth_preset: true,              // Use custom values for small scenes
+            // LUT Settings (from Bevy defaults)
+            transmittance_lut_size: (256, 64),
+            multiscattering_lut_size: (32, 32),
+            sky_view_lut_size: (192, 108),
+            aerial_view_lut_size: (32, 32, 32),
+            transmittance_lut_samples: 40,
+            multiscattering_lut_dirs: 64,
+            multiscattering_lut_samples: 20,
+            sky_view_lut_samples: 16,
+            aerial_view_lut_samples: 8,
+            aerial_view_lut_max_distance: 3.2e5,
+            scene_units_to_m: 1.0,
+            sky_max_samples: 16,
+            rendering_method: AtmosphereRenderingMethod::LookupTexture,
+            
+            // Atmosphere settings (Earth-like defaults)
             bottom_radius: 6360000.0,
-            top_radius:  6460000.0,
+            top_radius: 6460000.0,
             ground_albedo: (0.3, 0.3, 0.3),
             rayleigh_density_exp_scale: -0.125,
             rayleigh_scattering: (0.005802, 0.013558, 0.033100),

--- a/crates/bevy_granite_core/src/entities/editable/types/camera_3d/mod.rs
+++ b/crates/bevy_granite_core/src/entities/editable/types/camera_3d/mod.rs
@@ -10,7 +10,8 @@ use bevy::{
     },
     mesh::Mesh,
     pbr::StandardMaterial,
-    prelude::Reflect,
+    prelude::{Reflect, ReflectDefault},
+    reflect::FromReflect,
     transform::components::Transform,
 };
 use bevy_egui::egui;
@@ -36,20 +37,29 @@ pub struct UserUpdatedCamera3DEvent {
 /// Actual serialized class data thats stored inside IdentityData
 /// is_active is Bevy Camera3D data
 /// has_volumetric_fog and counterpart settings are custom to inject volumetrics easier
+/// has_atmosphere and counterpart settings are custom to inject atmosphere easier
 #[derive(Serialize, Deserialize, Reflect, Debug, Clone, PartialEq)]
 pub struct Camera3D {
     pub is_active: bool,
+    pub order: isize, // Camera render order - higher values render on top
     pub has_volumetric_fog: bool, // if true, our next update even will insert volumetric fog settings
+    pub has_atmosphere: bool,     // if true, our next update event will insert atmosphere settings
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub volumetric_fog_settings: Option<VolumetricFog>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub atmosphere_settings: Option<AtmosphereSettings>,
 }
 impl Default for Camera3D {
     fn default() -> Self {
         Self {
             is_active: true,
+            order: 0, 
             has_volumetric_fog: false,
             volumetric_fog_settings: None,
+            has_atmosphere: false,
+            atmosphere_settings: None,
         }
     }
 }
@@ -84,6 +94,50 @@ impl Default for VolumetricFog {
             scattering_asymmetry: 0.8,
             light_tint: Color::WHITE,
             light_intensity: 0.1,
+        }
+    }
+}
+
+/// Wrapper for bevy atmosphere settings that's serializable and optional
+/// Will need to keep in parity if Bevy changes how it stores these settings
+#[derive(Serialize, Deserialize, Reflect, Debug, Clone, PartialEq)]
+pub struct AtmosphereSettings {
+    pub aerial_view_lut_max_distance: f32,
+    pub scene_units_to_m: f32,
+    pub use_earth_preset: bool, // If true, uses Atmosphere::EARTH preset
+    // Atmosphere component fields
+    pub bottom_radius: f32,
+    pub top_radius: f32,
+    pub ground_albedo: (f32, f32, f32), // Vec3 as tuple for serialization
+    pub rayleigh_density_exp_scale: f32,
+    pub rayleigh_scattering: (f32, f32, f32), // Vec3 as tuple
+    pub mie_density_exp_scale: f32,
+    pub mie_scattering: f32,
+    pub mie_absorption: f32,
+    pub mie_asymmetry: f32,
+    pub ozone_layer_altitude: f32,
+    pub ozone_layer_width: f32,
+    pub ozone_absorption: (f32, f32, f32), // Vec3 as tuple
+}
+impl Default for AtmosphereSettings {
+    fn default() -> Self {
+        // Scaled for small scenes (100m x 100m)
+        Self {
+            aerial_view_lut_max_distance:  3.2e5,
+            scene_units_to_m: 1.0,                // 1 scene unit = 1 meter
+            use_earth_preset: true,              // Use custom values for small scenes
+            bottom_radius: 6360000.0,
+            top_radius:  6460000.0,
+            ground_albedo: (0.3, 0.3, 0.3),
+            rayleigh_density_exp_scale: -0.125,
+            rayleigh_scattering: (0.005802, 0.013558, 0.033100),
+            mie_density_exp_scale: -0.833333,
+            mie_scattering: 0.003996,
+            mie_absorption: 0.000444,
+            mie_asymmetry: 0.8,
+            ozone_layer_altitude: 25000.0,
+            ozone_layer_width: 15000.0,
+            ozone_absorption: (0.000650, 0.001881, 0.000085),
         }
     }
 }

--- a/crates/bevy_granite_core/src/entities/editable/types/camera_3d/plugin.rs
+++ b/crates/bevy_granite_core/src/entities/editable/types/camera_3d/plugin.rs
@@ -1,4 +1,4 @@
-use super::{update_camera_3d_system, UserUpdatedCamera3DEvent};
+use super::{update_camera_3d_system, UserUpdatedCamera3DEvent, AtmosphereSettings};
 use crate::Camera3D;
 use bevy::app::{App, Plugin, Update};
 
@@ -14,6 +14,7 @@ impl Plugin for Camera3DPlugin {
             // Register
             //
             .register_type::<Camera3D>()
+            .register_type::<AtmosphereSettings>()
             //
             // Schedule system
             //

--- a/crates/bevy_granite_core/src/entities/editable/types/camera_3d/ui.rs
+++ b/crates/bevy_granite_core/src/entities/editable/types/camera_3d/ui.rs
@@ -1,5 +1,5 @@
 use crate::GraniteType;
-use super::Camera3D;
+use super::{AtmosphereRenderingMethod, Camera3D};
 use bevy_egui::egui;
 
 impl Camera3D {
@@ -15,6 +15,7 @@ impl Camera3D {
         let type_name = self.type_name();
         let data = self;
         let large_spacing = spacing.1;
+        let small_spacing = spacing.0;
 
         ui.label(egui::RichText::new(type_name).italics());
         ui.add_space(large_spacing);
@@ -191,6 +192,11 @@ impl Camera3D {
 
             if *atmosphere_enabled {
                 ui.collapsing("Atmosphere", |ui| {
+                    ui.separator();
+                    ui.label("Will break EGUI inside viewport.");
+                    ui.label("Need to change order to be higher than other cameras.");
+                    ui.label("Toggle Editor/On off to get back to viewport camera.");
+                    ui.separator();
                     egui::Grid::new("atmosphere_grid")
                         .num_columns(2)
                         .spacing([large_spacing, large_spacing])
@@ -199,8 +205,55 @@ impl Camera3D {
                             let found_atmosphere = &mut data.atmosphere_settings;
 
                             if let Some(atmos_settings) = found_atmosphere {
-                                ui.label("Use Earth Preset:");
-                                changed |= ui.checkbox(&mut atmos_settings.use_earth_preset, "").changed();
+                                ui.horizontal(|ui| {
+                                    // Button to reset to Earth preset values from Bevy::Atmosphere::EARTH
+                                    if ui.button("Earth").clicked() {
+                                        let earth = bevy::pbr::Atmosphere::EARTH;
+                                        atmos_settings.bottom_radius = earth.bottom_radius;
+                                        atmos_settings.top_radius = earth.top_radius;
+                                        atmos_settings.ground_albedo = (earth.ground_albedo.x, earth.ground_albedo.y, earth.ground_albedo.z);
+                                        atmos_settings.rayleigh_density_exp_scale = earth.rayleigh_density_exp_scale;
+                                        atmos_settings.rayleigh_scattering = (earth.rayleigh_scattering.x, earth.rayleigh_scattering.y, earth.rayleigh_scattering.z);
+                                        atmos_settings.mie_density_exp_scale = earth.mie_density_exp_scale;
+                                        atmos_settings.mie_scattering = earth.mie_scattering;
+                                        atmos_settings.mie_absorption = earth.mie_absorption;
+                                        atmos_settings.mie_asymmetry = earth.mie_asymmetry;
+                                        atmos_settings.ozone_layer_altitude = earth.ozone_layer_altitude;
+                                        atmos_settings.ozone_layer_width = earth.ozone_layer_width;
+                                        atmos_settings.ozone_absorption = (earth.ozone_absorption.x, earth.ozone_absorption.y, earth.ozone_absorption.z);
+                                        changed = true;
+                                    }
+                                    ui.add_space(small_spacing);
+                                    
+                                    if ui.button("Earth - Ground").clicked() {
+                                        let earth = bevy::pbr::Atmosphere::EARTH;
+                                        atmos_settings.bottom_radius = 6_360_000.;
+                                        atmos_settings.top_radius = 6_370_000.;
+                                        atmos_settings.ground_albedo = (earth.ground_albedo.x, earth.ground_albedo.y, earth.ground_albedo.z);
+                                        atmos_settings.rayleigh_density_exp_scale = earth.rayleigh_density_exp_scale;
+                                        atmos_settings.rayleigh_scattering = (earth.rayleigh_scattering.x, earth.rayleigh_scattering.y, earth.rayleigh_scattering.z);
+                                        atmos_settings.mie_density_exp_scale = earth.mie_density_exp_scale;
+                                        atmos_settings.mie_scattering = earth.mie_scattering;
+                                        atmos_settings.mie_absorption = earth.mie_absorption;
+                                        atmos_settings.mie_asymmetry = earth.mie_asymmetry;
+                                        atmos_settings.ozone_layer_altitude = earth.ozone_layer_altitude;
+                                        atmos_settings.ozone_layer_width = earth.ozone_layer_width;
+                                        atmos_settings.ozone_absorption = (earth.ozone_absorption.x, earth.ozone_absorption.y, earth.ozone_absorption.z);
+                                        changed = true;
+                                    }
+                                });
+                                ui.end_row();
+                                
+                                ui.separator();
+                                ui.end_row();
+
+                                ui.label("Rendering Method:");
+                                egui::ComboBox::from_id_salt("atmosphere_rendering_method")
+                                    .selected_text(format!("{:?}", atmos_settings.rendering_method))
+                                    .show_ui(ui, |ui| {
+                                        changed |= ui.selectable_value(&mut atmos_settings.rendering_method, AtmosphereRenderingMethod::LookupTexture, "LookupTexture").changed();
+                                        changed |= ui.selectable_value(&mut atmos_settings.rendering_method, AtmosphereRenderingMethod::Raymarched, "Raymarched").changed();
+                                    });
                                 ui.end_row();
 
                                 ui.label("Aerial View LUT Max Distance:");
@@ -223,124 +276,129 @@ impl Camera3D {
                                     .changed();
                                 ui.end_row();
 
-                                // Only show detailed controls if not using Earth preset
-                                if !atmos_settings.use_earth_preset {
-                                    ui.label("Bottom Radius:");
-                                    changed |= ui
-                                        .add(
-                                            egui::DragValue::new(&mut atmos_settings.bottom_radius)
-                                                .range(1000.0..=10000000.0)
-                                                .speed(1000.0),
-                                        )
-                                        .changed();
-                                    ui.end_row();
+                                ui.label("Bottom Radius:");
+                                changed |= ui
+                                    .add(
+                                        egui::DragValue::new(&mut atmos_settings.bottom_radius)
+                                            .range(-10_000_000.0..=10_000_000.0)
+                                            .speed(10000.0)
+                                            .suffix(" m"),
+                                    )
+                                    .changed();
+                                ui.end_row();
 
-                                    ui.label("Top Radius:");
-                                    changed |= ui
-                                        .add(
-                                            egui::DragValue::new(&mut atmos_settings.top_radius)
-                                                .range(1000.0..=10000000.0)
-                                                .speed(1000.0),
-                                        )
-                                        .changed();
-                                    ui.end_row();
+                                ui.label("Top Radius:");
+                                changed |= ui
+                                    .add(
+                                        egui::DragValue::new(&mut atmos_settings.top_radius)
+                                            .range(-10_000_000.0..=10000000.0)
+                                            .speed(10_000.0)
+                                            .suffix(" m"),
+                                    )
+                                    .changed();
+                                ui.end_row();
 
-                                    ui.label("Ground Albedo:");
-                                    ui.horizontal(|ui| {
-                                        changed |= ui.add(egui::DragValue::new(&mut atmos_settings.ground_albedo.0).range(0.0..=1.0).speed(0.01).prefix("R: ")).changed();
-                                        changed |= ui.add(egui::DragValue::new(&mut atmos_settings.ground_albedo.1).range(0.0..=1.0).speed(0.01).prefix("G: ")).changed();
-                                        changed |= ui.add(egui::DragValue::new(&mut atmos_settings.ground_albedo.2).range(0.0..=1.0).speed(0.01).prefix("B: ")).changed();
-                                    });
-                                    ui.end_row();
+                                ui.label("Ground Albedo:");
+                                ui.horizontal(|ui| {
+                                    changed |= ui.add(egui::DragValue::new(&mut atmos_settings.ground_albedo.0).range(0.0..=1.0).speed(0.01).prefix("R: ")).changed();
+                                    changed |= ui.add(egui::DragValue::new(&mut atmos_settings.ground_albedo.1).range(0.0..=1.0).speed(0.01).prefix("G: ")).changed();
+                                    changed |= ui.add(egui::DragValue::new(&mut atmos_settings.ground_albedo.2).range(0.0..=1.0).speed(0.01).prefix("B: ")).changed();
+                                });
+                                ui.end_row();
 
-                                    ui.label("Rayleigh Density Exp Scale:");
-                                    changed |= ui
-                                        .add(
-                                            egui::DragValue::new(&mut atmos_settings.rayleigh_density_exp_scale)
-                                                .range(-10.0..=0.0)
-                                                .speed(0.001),
-                                        )
-                                        .changed();
-                                    ui.end_row();
+                                ui.label("Rayleigh Density Exp Scale:");
+                                changed |= ui
+                                    .add(
+                                        egui::DragValue::new(&mut atmos_settings.rayleigh_density_exp_scale)
+                                            .range(0.0..=1.0)
+                                            .speed(0.01)
+                                            .custom_formatter(|n, _| format!("{:.3}", n)),
+                                    )
+                                    .changed();
+                                ui.end_row();
 
-                                    ui.label("Rayleigh Scattering:");
-                                    ui.horizontal(|ui| {
-                                        changed |= ui.add(egui::DragValue::new(&mut atmos_settings.rayleigh_scattering.0).range(0.0..=1.0).speed(0.0001).prefix("R: ")).changed();
-                                        changed |= ui.add(egui::DragValue::new(&mut atmos_settings.rayleigh_scattering.1).range(0.0..=1.0).speed(0.0001).prefix("G: ")).changed();
-                                        changed |= ui.add(egui::DragValue::new(&mut atmos_settings.rayleigh_scattering.2).range(0.0..=1.0).speed(0.0001).prefix("B: ")).changed();
-                                    });
-                                    ui.end_row();
+                                ui.label("Rayleigh Scattering:");
+                                ui.horizontal(|ui| {
+                                    changed |= ui.add(egui::DragValue::new(&mut atmos_settings.rayleigh_scattering.0).range(0.0..=0.1).speed(0.00001).custom_formatter(|n, _| format!("{:.6}", n)).prefix("R: ")).changed();
+                                    changed |= ui.add(egui::DragValue::new(&mut atmos_settings.rayleigh_scattering.1).range(0.0..=0.1).speed(0.00001).custom_formatter(|n, _| format!("{:.6}", n)).prefix("G: ")).changed();
+                                    changed |= ui.add(egui::DragValue::new(&mut atmos_settings.rayleigh_scattering.2).range(0.0..=0.1).speed(0.00001).custom_formatter(|n, _| format!("{:.6}", n)).prefix("B: ")).changed();
+                                });
+                                ui.end_row();
 
-                                    ui.label("Mie Density Exp Scale:");
-                                    changed |= ui
-                                        .add(
-                                            egui::DragValue::new(&mut atmos_settings.mie_density_exp_scale)
-                                                .range(-10.0..=0.0)
-                                                .speed(0.01),
-                                        )
-                                        .changed();
-                                    ui.end_row();
+                                ui.label("Mie Density Exp Scale:");
+                                changed |= ui
+                                    .add(
+                                        egui::DragValue::new(&mut atmos_settings.mie_density_exp_scale)
+                                            .range(0.0..=10.0)
+                                            .speed(0.05)
+                                            .custom_formatter(|n, _| format!("{:.3}", n)),
+                                    )
+                                    .changed();
+                                ui.end_row();
 
-                                    ui.label("Mie Scattering:");
-                                    changed |= ui
-                                        .add(
-                                            egui::DragValue::new(&mut atmos_settings.mie_scattering)
-                                                .range(0.0..=1.0)
-                                                .speed(0.0001),
-                                        )
-                                        .changed();
-                                    ui.end_row();
+                                ui.label("Mie Scattering:");
+                                changed |= ui
+                                    .add(
+                                        egui::DragValue::new(&mut atmos_settings.mie_scattering)
+                                            .range(0.0..=0.1)
+                                            .speed(0.00001)
+                                            .custom_formatter(|n, _| format!("{:.6}", n)),
+                                    )
+                                    .changed();
+                                ui.end_row();
 
-                                    ui.label("Mie Absorption:");
-                                    changed |= ui
-                                        .add(
-                                            egui::DragValue::new(&mut atmos_settings.mie_absorption)
-                                                .range(0.0..=1.0)
-                                                .speed(0.0001),
-                                        )
-                                        .changed();
-                                    ui.end_row();
+                                ui.label("Mie Absorption:");
+                                changed |= ui
+                                    .add(
+                                        egui::DragValue::new(&mut atmos_settings.mie_absorption)
+                                            .range(0.0..=0.1)
+                                            .speed(0.00001)
+                                            .custom_formatter(|n, _| format!("{:.6}", n)),
+                                    )
+                                    .changed();
+                                ui.end_row();
 
-                                    ui.label("Mie Asymmetry:");
-                                    changed |= ui
-                                        .add(
-                                            egui::DragValue::new(&mut atmos_settings.mie_asymmetry)
-                                                .range(-1.0..=1.0)
-                                                .speed(0.01),
-                                        )
-                                        .changed();
-                                    ui.end_row();
+                                ui.label("Mie Asymmetry:");
+                                changed |= ui
+                                    .add(
+                                        egui::DragValue::new(&mut atmos_settings.mie_asymmetry)
+                                            .range(-1.0..=1.0)
+                                            .speed(0.01)
+                                            .custom_formatter(|n, _| format!("{:.2}", n)),
+                                    )
+                                    .changed();
+                                ui.end_row();
 
-                                    ui.label("Ozone Layer Altitude:");
-                                    changed |= ui
-                                        .add(
-                                            egui::DragValue::new(&mut atmos_settings.ozone_layer_altitude)
-                                                .range(0.0..=100000.0)
-                                                .speed(100.0),
-                                        )
-                                        .changed();
-                                    ui.end_row();
+                                ui.label("Ozone Layer Altitude:");
+                                changed |= ui
+                                    .add(
+                                        egui::DragValue::new(&mut atmos_settings.ozone_layer_altitude)
+                                            .range(0.0..=100000.0)
+                                            .speed(500.0)
+                                            .suffix(" m"),
+                                    )
+                                    .changed();
+                                ui.end_row();
 
-                                    ui.label("Ozone Layer Width:");
-                                    changed |= ui
-                                        .add(
-                                            egui::DragValue::new(&mut atmos_settings.ozone_layer_width)
-                                                .range(0.0..=100000.0)
-                                                .speed(100.0),
-                                        )
-                                        .changed();
-                                    ui.end_row();
+                                ui.label("Ozone Layer Width:");
+                                changed |= ui
+                                    .add(
+                                        egui::DragValue::new(&mut atmos_settings.ozone_layer_width)
+                                            .range(0.0..=100000.0)
+                                            .speed(500.0)
+                                            .suffix(" m"),
+                                    )
+                                    .changed();
+                                ui.end_row();
 
-                                    ui.label("Ozone Absorption:");
-                                    ui.horizontal(|ui| {
-                                        changed |= ui.add(egui::DragValue::new(&mut atmos_settings.ozone_absorption.0).range(0.0..=1.0).speed(0.00001).prefix("R: ")).changed();
-                                        changed |= ui.add(egui::DragValue::new(&mut atmos_settings.ozone_absorption.1).range(0.0..=1.0).speed(0.00001).prefix("G: ")).changed();
-                                        changed |= ui.add(egui::DragValue::new(&mut atmos_settings.ozone_absorption.2).range(0.0..=1.0).speed(0.00001).prefix("B: ")).changed();
-                                    });
-                                    ui.end_row();
-                                }
+                                ui.label("Ozone Absorption:");
+                                ui.horizontal(|ui| {
+                                    changed |= ui.add(egui::DragValue::new(&mut atmos_settings.ozone_absorption.0).range(0.0..=0.01).speed(0.000001).custom_formatter(|n, _| format!("{:.6}", n)).prefix("R: ")).changed();
+                                    changed |= ui.add(egui::DragValue::new(&mut atmos_settings.ozone_absorption.1).range(0.0..=0.01).speed(0.000001).custom_formatter(|n, _| format!("{:.6}", n)).prefix("G: ")).changed();
+                                    changed |= ui.add(egui::DragValue::new(&mut atmos_settings.ozone_absorption.2).range(0.0..=0.01).speed(0.000001).custom_formatter(|n, _| format!("{:.6}", n)).prefix("B: ")).changed();
+                                });
+                                ui.end_row();
                             } else {
-                                // Initialize atmosphere settings if they don't exist
                                 *found_atmosphere = Some(super::AtmosphereSettings::default());
                             }
                         });

--- a/crates/bevy_granite_core/src/entities/editable/types/camera_3d/ui.rs
+++ b/crates/bevy_granite_core/src/entities/editable/types/camera_3d/ui.rs
@@ -21,6 +21,7 @@ impl Camera3D {
 
         let mut changed = false;
         let mut fog_enabled = &mut data.has_volumetric_fog;
+        let mut atmosphere_enabled = &mut data.has_atmosphere;
         ui.vertical(|ui| {
             egui::Grid::new("camera_settings_grid")
                 .num_columns(2)
@@ -30,8 +31,14 @@ impl Camera3D {
                     ui.label("Is active:");
                     changed |= ui.checkbox(&mut data.is_active, "").changed();
                     ui.end_row();
+                    ui.label("Render Order:");
+                    changed |= ui.add(egui::DragValue::new(&mut data.order).speed(1)).changed();
+                    ui.end_row();
                     ui.label("Volumetric Fog:");
                     changed |= ui.checkbox(&mut fog_enabled, "").changed();
+                    ui.end_row();
+                    ui.label("Atmosphere:");
+                    changed |= ui.checkbox(&mut atmosphere_enabled, "").changed();
                     ui.end_row();
                 });
             ui.add_space(large_spacing);
@@ -178,6 +185,164 @@ impl Camera3D {
                                     .changed();
                                 ui.end_row();
                             };
+                        });
+                });
+            };
+
+            if *atmosphere_enabled {
+                ui.collapsing("Atmosphere", |ui| {
+                    egui::Grid::new("atmosphere_grid")
+                        .num_columns(2)
+                        .spacing([large_spacing, large_spacing])
+                        .striped(true)
+                        .show(ui, |ui| {
+                            let found_atmosphere = &mut data.atmosphere_settings;
+
+                            if let Some(atmos_settings) = found_atmosphere {
+                                ui.label("Use Earth Preset:");
+                                changed |= ui.checkbox(&mut atmos_settings.use_earth_preset, "").changed();
+                                ui.end_row();
+
+                                ui.label("Aerial View LUT Max Distance:");
+                                changed |= ui
+                                    .add(
+                                        egui::DragValue::new(&mut atmos_settings.aerial_view_lut_max_distance)
+                                            .range(1000.0..=1000000.0)
+                                            .speed(1000.0),
+                                    )
+                                    .changed();
+                                ui.end_row();
+
+                                ui.label("Scene Units to Meters:");
+                                changed |= ui
+                                    .add(
+                                        egui::DragValue::new(&mut atmos_settings.scene_units_to_m)
+                                            .range(0.001..=100000.0)
+                                            .speed(100.0),
+                                    )
+                                    .changed();
+                                ui.end_row();
+
+                                // Only show detailed controls if not using Earth preset
+                                if !atmos_settings.use_earth_preset {
+                                    ui.label("Bottom Radius:");
+                                    changed |= ui
+                                        .add(
+                                            egui::DragValue::new(&mut atmos_settings.bottom_radius)
+                                                .range(1000.0..=10000000.0)
+                                                .speed(1000.0),
+                                        )
+                                        .changed();
+                                    ui.end_row();
+
+                                    ui.label("Top Radius:");
+                                    changed |= ui
+                                        .add(
+                                            egui::DragValue::new(&mut atmos_settings.top_radius)
+                                                .range(1000.0..=10000000.0)
+                                                .speed(1000.0),
+                                        )
+                                        .changed();
+                                    ui.end_row();
+
+                                    ui.label("Ground Albedo:");
+                                    ui.horizontal(|ui| {
+                                        changed |= ui.add(egui::DragValue::new(&mut atmos_settings.ground_albedo.0).range(0.0..=1.0).speed(0.01).prefix("R: ")).changed();
+                                        changed |= ui.add(egui::DragValue::new(&mut atmos_settings.ground_albedo.1).range(0.0..=1.0).speed(0.01).prefix("G: ")).changed();
+                                        changed |= ui.add(egui::DragValue::new(&mut atmos_settings.ground_albedo.2).range(0.0..=1.0).speed(0.01).prefix("B: ")).changed();
+                                    });
+                                    ui.end_row();
+
+                                    ui.label("Rayleigh Density Exp Scale:");
+                                    changed |= ui
+                                        .add(
+                                            egui::DragValue::new(&mut atmos_settings.rayleigh_density_exp_scale)
+                                                .range(-10.0..=0.0)
+                                                .speed(0.001),
+                                        )
+                                        .changed();
+                                    ui.end_row();
+
+                                    ui.label("Rayleigh Scattering:");
+                                    ui.horizontal(|ui| {
+                                        changed |= ui.add(egui::DragValue::new(&mut atmos_settings.rayleigh_scattering.0).range(0.0..=1.0).speed(0.0001).prefix("R: ")).changed();
+                                        changed |= ui.add(egui::DragValue::new(&mut atmos_settings.rayleigh_scattering.1).range(0.0..=1.0).speed(0.0001).prefix("G: ")).changed();
+                                        changed |= ui.add(egui::DragValue::new(&mut atmos_settings.rayleigh_scattering.2).range(0.0..=1.0).speed(0.0001).prefix("B: ")).changed();
+                                    });
+                                    ui.end_row();
+
+                                    ui.label("Mie Density Exp Scale:");
+                                    changed |= ui
+                                        .add(
+                                            egui::DragValue::new(&mut atmos_settings.mie_density_exp_scale)
+                                                .range(-10.0..=0.0)
+                                                .speed(0.01),
+                                        )
+                                        .changed();
+                                    ui.end_row();
+
+                                    ui.label("Mie Scattering:");
+                                    changed |= ui
+                                        .add(
+                                            egui::DragValue::new(&mut atmos_settings.mie_scattering)
+                                                .range(0.0..=1.0)
+                                                .speed(0.0001),
+                                        )
+                                        .changed();
+                                    ui.end_row();
+
+                                    ui.label("Mie Absorption:");
+                                    changed |= ui
+                                        .add(
+                                            egui::DragValue::new(&mut atmos_settings.mie_absorption)
+                                                .range(0.0..=1.0)
+                                                .speed(0.0001),
+                                        )
+                                        .changed();
+                                    ui.end_row();
+
+                                    ui.label("Mie Asymmetry:");
+                                    changed |= ui
+                                        .add(
+                                            egui::DragValue::new(&mut atmos_settings.mie_asymmetry)
+                                                .range(-1.0..=1.0)
+                                                .speed(0.01),
+                                        )
+                                        .changed();
+                                    ui.end_row();
+
+                                    ui.label("Ozone Layer Altitude:");
+                                    changed |= ui
+                                        .add(
+                                            egui::DragValue::new(&mut atmos_settings.ozone_layer_altitude)
+                                                .range(0.0..=100000.0)
+                                                .speed(100.0),
+                                        )
+                                        .changed();
+                                    ui.end_row();
+
+                                    ui.label("Ozone Layer Width:");
+                                    changed |= ui
+                                        .add(
+                                            egui::DragValue::new(&mut atmos_settings.ozone_layer_width)
+                                                .range(0.0..=100000.0)
+                                                .speed(100.0),
+                                        )
+                                        .changed();
+                                    ui.end_row();
+
+                                    ui.label("Ozone Absorption:");
+                                    ui.horizontal(|ui| {
+                                        changed |= ui.add(egui::DragValue::new(&mut atmos_settings.ozone_absorption.0).range(0.0..=1.0).speed(0.00001).prefix("R: ")).changed();
+                                        changed |= ui.add(egui::DragValue::new(&mut atmos_settings.ozone_absorption.1).range(0.0..=1.0).speed(0.00001).prefix("G: ")).changed();
+                                        changed |= ui.add(egui::DragValue::new(&mut atmos_settings.ozone_absorption.2).range(0.0..=1.0).speed(0.00001).prefix("B: ")).changed();
+                                    });
+                                    ui.end_row();
+                                }
+                            } else {
+                                // Initialize atmosphere settings if they don't exist
+                                *found_atmosphere = Some(super::AtmosphereSettings::default());
+                            }
                         });
                 });
             };

--- a/crates/bevy_granite_core/src/entities/editable/types/camera_3d/update_event.rs
+++ b/crates/bevy_granite_core/src/entities/editable/types/camera_3d/update_event.rs
@@ -1,4 +1,4 @@
-use super::{UserUpdatedCamera3DEvent, VolumetricFog};
+use super::{AtmosphereRenderingMethod, UserUpdatedCamera3DEvent, VolumetricFog};
 use crate::{
     entities::editable::RequestEntityUpdateFromClass, Camera3D, GraniteTypes, IdentityData,
 };
@@ -10,7 +10,9 @@ use bevy::{
         system::{Commands, Query},
     },
     light::{FogVolume, VolumetricFog as VolumetricFogSettings},
-    pbr::{Atmosphere, AtmosphereSettings as BevyAtmosphereSettings}, render::view::Hdr,
+    math::{UVec2, UVec3},
+    pbr::{Atmosphere, AtmosphereMode, AtmosphereSettings as BevyAtmosphereSettings},
+    render::view::Hdr,
 };
 
 use bevy_granite_logging::{log, LogCategory, LogLevel, LogType};
@@ -52,8 +54,9 @@ pub fn update_camera_3d_system(
             LogType::Editor,
             LogLevel::Info,
             LogCategory::Entity,
-            "Heard camera3d update event: {}",
-            requested_entity
+            "Heard camera3d update event: {} - has_atmosphere: {}",
+            requested_entity,
+            new.has_atmosphere
         );
         if let Ok((entity, mut camera, mut identity_data)) = query.get_mut(*requested_entity) {
             if new.is_active {
@@ -95,62 +98,97 @@ pub fn update_camera_3d_system(
             if new.has_atmosphere {
                 let atmos_config = new.atmosphere_settings.clone().unwrap_or_default();
 
-                // Add Atmosphere component (using EARTH preset if enabled, otherwise use custom values)
-                let atmosphere = if atmos_config.use_earth_preset {
-                    Atmosphere::EARTH
-                } else {
-                    Atmosphere {
-                        bottom_radius: atmos_config.bottom_radius,
-                        top_radius: atmos_config.top_radius,
-                        ground_albedo: atmos_config.ground_albedo.into(),
-                        rayleigh_density_exp_scale: atmos_config.rayleigh_density_exp_scale,
-                        rayleigh_scattering: atmos_config.rayleigh_scattering.into(),
-                        mie_density_exp_scale: atmos_config.mie_density_exp_scale,
-                        mie_scattering: atmos_config.mie_scattering,
-                        mie_absorption: atmos_config.mie_absorption,
-                        mie_asymmetry: atmos_config.mie_asymmetry,
-                        ozone_layer_altitude: atmos_config.ozone_layer_altitude,
-                        ozone_layer_width: atmos_config.ozone_layer_width,
-                        ozone_absorption: atmos_config.ozone_absorption.into(),
-                    }
+                log!(
+                    LogType::Editor,
+                    LogLevel::Info,
+                    LogCategory::Entity,
+                    "Applying atmosphere - bottom_radius: {}, top_radius: {}",
+                    atmos_config.bottom_radius,
+                    atmos_config.top_radius
+                );
+
+                // The UI can populate these with EARTH preset values if the checkbox is enabled
+                let atmosphere = Atmosphere {
+                    bottom_radius: atmos_config.bottom_radius,
+                    top_radius: atmos_config.top_radius,
+                    ground_albedo: atmos_config.ground_albedo.into(),
+                    rayleigh_density_exp_scale: atmos_config.rayleigh_density_exp_scale,
+                    rayleigh_scattering: atmos_config.rayleigh_scattering.into(),
+                    mie_density_exp_scale: atmos_config.mie_density_exp_scale,
+                    mie_scattering: atmos_config.mie_scattering,
+                    mie_absorption: atmos_config.mie_absorption,
+                    mie_asymmetry: atmos_config.mie_asymmetry,
+                    ozone_layer_altitude: atmos_config.ozone_layer_altitude,
+                    ozone_layer_width: atmos_config.ozone_layer_width,
+                    ozone_absorption: atmos_config.ozone_absorption.into(),
                 };
 
                 commands.entity(entity).insert(Hdr);
                 commands.entity(entity).insert(atmosphere);
 
-                // Add AtmosphereSettings component
+                // Convert rendering method
+                let rendering_mode = match atmos_config.rendering_method {
+                    AtmosphereRenderingMethod::LookupTexture => AtmosphereMode::LookupTexture,
+                    AtmosphereRenderingMethod::Raymarched => AtmosphereMode::Raymarched,
+                };
+
                 commands.entity(entity).insert(BevyAtmosphereSettings {
+                    transmittance_lut_size: UVec2::new(
+                        atmos_config.transmittance_lut_size.0,
+                        atmos_config.transmittance_lut_size.1,
+                    ),
+                    multiscattering_lut_size: UVec2::new(
+                        atmos_config.multiscattering_lut_size.0,
+                        atmos_config.multiscattering_lut_size.1,
+                    ),
+                    sky_view_lut_size: UVec2::new(
+                        atmos_config.sky_view_lut_size.0,
+                        atmos_config.sky_view_lut_size.1,
+                    ),
+                    aerial_view_lut_size: UVec3::new(
+                        atmos_config.aerial_view_lut_size.0,
+                        atmos_config.aerial_view_lut_size.1,
+                        atmos_config.aerial_view_lut_size.2,
+                    ),
+                    transmittance_lut_samples: atmos_config.transmittance_lut_samples,
+                    multiscattering_lut_dirs: atmos_config.multiscattering_lut_dirs,
+                    multiscattering_lut_samples: atmos_config.multiscattering_lut_samples,
+                    sky_view_lut_samples: atmos_config.sky_view_lut_samples,
+                    aerial_view_lut_samples: atmos_config.aerial_view_lut_samples,
                     aerial_view_lut_max_distance: atmos_config.aerial_view_lut_max_distance,
                     scene_units_to_m: atmos_config.scene_units_to_m,
+                    sky_max_samples: atmos_config.sky_max_samples,
+                    rendering_method: rendering_mode,
                     ..Default::default()
                 });
             } else {
                 commands
                     .entity(entity)
-                    .remove::<(Atmosphere, BevyAtmosphereSettings)>();
+                    .remove::<(Atmosphere, BevyAtmosphereSettings, Hdr)>();
+                
+                log!(
+                    LogType::Editor,
+                    LogLevel::Info,
+                    LogCategory::Entity,
+                    "Removed atmosphere from camera: {}",
+                    entity
+                );
             }
 
-            // Update the IdentityData to match new changes
             if let GraniteTypes::Camera3D(ref mut camera_data) = identity_data.class {
                 camera_data.is_active = new.is_active;
+                camera_data.order = new.order;
                 camera_data.has_volumetric_fog = new.has_volumetric_fog;
                 camera_data.has_atmosphere = new.has_atmosphere;
 
                 if new.has_volumetric_fog {
-                    // Ensure volumetric_fog_settings is populated
-                    if camera_data.volumetric_fog_settings.is_none() {
-                        camera_data.volumetric_fog_settings = Some(VolumetricFog::default());
-                    }
+                    camera_data.volumetric_fog_settings = new.volumetric_fog_settings.clone();
                 } else {
                     camera_data.volumetric_fog_settings = None;
                 }
 
                 if new.has_atmosphere {
-                    // Ensure atmosphere_settings is populated
-                    if camera_data.atmosphere_settings.is_none() {
-                        camera_data.atmosphere_settings =
-                            Some(super::AtmosphereSettings::default());
-                    }
+                    camera_data.atmosphere_settings = new.atmosphere_settings.clone();
                 } else {
                     camera_data.atmosphere_settings = None;
                 }

--- a/crates/bevy_granite_core/src/entities/editable/types/camera_3d/update_event.rs
+++ b/crates/bevy_granite_core/src/entities/editable/types/camera_3d/update_event.rs
@@ -10,6 +10,7 @@ use bevy::{
         system::{Commands, Query},
     },
     light::{FogVolume, VolumetricFog as VolumetricFogSettings},
+    pbr::{Atmosphere, AtmosphereSettings as BevyAtmosphereSettings}, render::view::Hdr,
 };
 
 use bevy_granite_logging::{log, LogCategory, LogLevel, LogType};
@@ -60,6 +61,9 @@ pub fn update_camera_3d_system(
             } else {
                 camera.is_active = false;
             }
+            
+            // Update camera render order
+            camera.order = new.order;
 
             if new.has_volumetric_fog {
                 let fog_config = new.volumetric_fog_settings.clone().unwrap_or_default();
@@ -87,10 +91,50 @@ pub fn update_camera_3d_system(
                     .remove::<(VolumetricFogSettings, FogVolume)>();
             }
 
+            // Handle atmosphere settings
+            if new.has_atmosphere {
+                let atmos_config = new.atmosphere_settings.clone().unwrap_or_default();
+
+                // Add Atmosphere component (using EARTH preset if enabled, otherwise use custom values)
+                let atmosphere = if atmos_config.use_earth_preset {
+                    Atmosphere::EARTH
+                } else {
+                    Atmosphere {
+                        bottom_radius: atmos_config.bottom_radius,
+                        top_radius: atmos_config.top_radius,
+                        ground_albedo: atmos_config.ground_albedo.into(),
+                        rayleigh_density_exp_scale: atmos_config.rayleigh_density_exp_scale,
+                        rayleigh_scattering: atmos_config.rayleigh_scattering.into(),
+                        mie_density_exp_scale: atmos_config.mie_density_exp_scale,
+                        mie_scattering: atmos_config.mie_scattering,
+                        mie_absorption: atmos_config.mie_absorption,
+                        mie_asymmetry: atmos_config.mie_asymmetry,
+                        ozone_layer_altitude: atmos_config.ozone_layer_altitude,
+                        ozone_layer_width: atmos_config.ozone_layer_width,
+                        ozone_absorption: atmos_config.ozone_absorption.into(),
+                    }
+                };
+
+                commands.entity(entity).insert(Hdr);
+                commands.entity(entity).insert(atmosphere);
+
+                // Add AtmosphereSettings component
+                commands.entity(entity).insert(BevyAtmosphereSettings {
+                    aerial_view_lut_max_distance: atmos_config.aerial_view_lut_max_distance,
+                    scene_units_to_m: atmos_config.scene_units_to_m,
+                    ..Default::default()
+                });
+            } else {
+                commands
+                    .entity(entity)
+                    .remove::<(Atmosphere, BevyAtmosphereSettings)>();
+            }
+
             // Update the IdentityData to match new changes
             if let GraniteTypes::Camera3D(ref mut camera_data) = identity_data.class {
                 camera_data.is_active = new.is_active;
                 camera_data.has_volumetric_fog = new.has_volumetric_fog;
+                camera_data.has_atmosphere = new.has_atmosphere;
 
                 if new.has_volumetric_fog {
                     // Ensure volumetric_fog_settings is populated
@@ -99,6 +143,16 @@ pub fn update_camera_3d_system(
                     }
                 } else {
                     camera_data.volumetric_fog_settings = None;
+                }
+
+                if new.has_atmosphere {
+                    // Ensure atmosphere_settings is populated
+                    if camera_data.atmosphere_settings.is_none() {
+                        camera_data.atmosphere_settings =
+                            Some(super::AtmosphereSettings::default());
+                    }
+                } else {
+                    camera_data.atmosphere_settings = None;
                 }
             }
         } else {

--- a/crates/bevy_granite_core/src/entities/editable/types/spot_light/ui.rs
+++ b/crates/bevy_granite_core/src/entities/editable/types/spot_light/ui.rs
@@ -42,7 +42,7 @@ impl SpotLightData {
                     changed |= ui
                         .add(
                             egui::DragValue::new(&mut data.intensity)
-                                .range(0.0..=1_000_000.0)
+                                .range(0.0..=4_000_000.0)
                                 .speed(100.0)
                                 .suffix(" lm"),
                         )

--- a/crates/bevy_granite_editor/src/interface/shared/widgets/combobox.rs
+++ b/crates/bevy_granite_editor/src/interface/shared/widgets/combobox.rs
@@ -104,7 +104,7 @@ fn generic_selector_popup<T: SelectableItem>(
 
         let area_response = egui::Area::new(popup_id)
             .fixed_pos(popup_pos)
-            .order(egui::Order::Foreground)
+            .order(egui::Order::TOP)
             .show(ui.ctx(), |ui: &mut egui::Ui| {
                 let frame = super::make_frame_solid(egui::Frame::popup(ui.style()), ui);
                 frame.show(ui, |ui: &mut egui::Ui| {


### PR DESCRIPTION
- Add optional atmosphere controls to Camera type
- Added order field to camera
- Breaks old camera structs

When you enable atmosphere, you need to set your camera to have a higher order than anything else. Which means egui will break inside the viewport. Tried a few things but didn't really find a good solution. Will be solved with coming up bevy_ui updates. 

<img width="3834" height="1971" alt="image" src="https://github.com/user-attachments/assets/a902df3b-6e5f-4dd8-add0-d921779452c0" />


<img width="2938" height="1327" alt="image" src="https://github.com/user-attachments/assets/2eb55cac-2a8d-4b78-ac95-774725963088" />

